### PR TITLE
Update Gherkin version to 9.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ See also the [CHANGELOG](https://github.com/cucumber/cucumber-jvm/blob/master/CH
   - Hooks definition changed
   - See [Upgrade Guide](docs/upgrade_v5.md)
 - [Build] Update Scala versions to 2.12.11 and 2.13.1 ([#23](https://github.com/cucumber/cucumber-jvm-scala/issues/23) Gaël Jourdan-Weil)
+- [Gherkin] Update Gherkin version to 9.2.0 
+  - New `MR` and `ME` traits available
 
 ### Deprecated
 

--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@
         <outputDirectory>${project.build.directory}</outputDirectory>
         <scala-maven-plugin.version>3.4.6</scala-maven-plugin.version>
         <cucumber.version>5.6.0</cucumber.version>
-        <gherkin.version>5.1.0</gherkin.version>
+        <gherkin.version>9.2.0</gherkin.version>
         <groovy.version>2.4.19</groovy.version>
         <jackson-databind.version>2.10.3</jackson-databind.version>
         <junit.version>4.12</junit.version>
@@ -143,6 +143,10 @@
                             <artifactId>groovy-all</artifactId>
                             <version>${groovy.version}</version>
                         </dependency>
+                        <!--
+                        Gherkin is used during build time to generate code. We add it to the plugin classpath to prevent polluting
+                        the compile/test classpaths.
+                        -->
                         <dependency>
                             <groupId>io.cucumber</groupId>
                             <artifactId>gherkin</artifactId>

--- a/scala/sources/src/main/groovy/I18n.scala.gsp
+++ b/scala/sources/src/main/groovy/I18n.scala.gsp
@@ -1,6 +1,6 @@
 package io.cucumber.scala
 
-<% gherkin.GherkinDialectProvider.DIALECTS.keySet().findAll { !unsupported.contains(it) }.each { language -> %>
+<% dialectProvider.getLanguages().findAll { !unsupported.contains(it) }.each { language -> %>
 trait ${language.replaceAll("[\\s-]", "_").toUpperCase()} {
   this: ScalaDsl =>
 <% dialectProvider.getDialect(language, null).stepKeywords.findAll { !it.contains('*') && !it.matches("^\\d.*") }.sort().unique().each { kw -> %>

--- a/scala/sources/src/main/groovy/generate-i18n-dsl.groovy
+++ b/scala/sources/src/main/groovy/generate-i18n-dsl.groovy
@@ -1,13 +1,15 @@
 import groovy.text.SimpleTemplateEngine
-import gherkin.GherkinDialectProvider
+import io.cucumber.gherkin.GherkinDialectProvider
 
 SimpleTemplateEngine engine = new SimpleTemplateEngine()
 def templateSource = new File(project.baseDir, "../sources/src/main/groovy/I18n.scala.gsp").getText()
 
-def unsupported = ["em"]
+def unsupported = ["em"] // The generated files for Emoji do not compile.
 GherkinDialectProvider dialectProvider = new GherkinDialectProvider()
+
 def binding = ["dialectProvider":dialectProvider, "unsupported":unsupported]
 template = engine.createTemplate(templateSource).make(binding)
+
 def file = new File(project.baseDir, "target/generated-sources/i18n/io/cucumber/scala/I18n.scala")
 file.parentFile.mkdirs()
 file.write(template.toString(), "UTF-8")


### PR DESCRIPTION
# Content
- Update Gherkin dependency for language traits generation to 9.2.0 (same as Cucumber Java).
- Update Groovy templates to use new `GherkinDialectProvider` methods