### PR TITLE
Allow to define transformers from ScalaDsl

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ The minor version might differ because Cucumber Scala may add Scala-related feat
   - [Basic usage](docs/usage.md)
   - [Step Definitions](docs/step_definitions.md)
   - [Hooks](docs/hooks.md)
+  - [Transformers](docs/transformers.md)
 - [Example project](examples/README.md)
 - [Reference documentation for Java](https://docs.cucumber.io/docs/cucumber/)
 - [Changelog](CHANGELOG.md)

--- a/docs/transformers.md
+++ b/docs/transformers.md
@@ -1,0 +1,326 @@
+# Transformers
+
+Transformers are glue code like step definitions or hooks.
+You have to define them in your glue classes.
+
+Cucumber allows the following specific transformers:
+- String to any type
+- DocString (multiline string) to any type
+- DataTable to any type
+  - transform lines with named headers to any type
+  - transform lines without headers to any type
+  - transform tables to any type
+  - transform cells content to any type
+
+As well as default transformers for:
+- String
+- DataTable
+  - lines with named headers
+  - cells
+
+## String to any
+
+`ParameterType` allows to transform a String value from a Cucumber expression to a custom type.
+
+It is defined by a name (used in the steps definitions) and a regex.
+Each group of the regex will map to a parameter of the transformation function.
+
+For instance, the following transformer can be defined:
+```scala
+case class Point(x: Int, y: Int)
+
+ParameterType("coordinates", "(.+),(.+)") { (x, y) =>
+  Point(x.toInt, y.toInt)
+}
+```
+
+And used like this:
+```gherkin
+Given balloon coordinates 123,456 in the game
+```
+
+```scala
+Given("balloon coordinates {coordinates} in the game") { (coordinates: Point) =>
+  // Do something with the coordinates
+}
+```
+
+**Limitation:** there is a current limitation to 22 parameters in the `ParameterType` definition.
+
+## DocString to any
+
+`DocStringType` allows to transform DocString values (multiline string) to a custom type.
+
+For instance, the following transformer can be defined:
+```scala
+case class JsonText(json: String)
+
+DocStringType("json") { text =>
+  JsonText(text)
+}
+```
+
+And used like this:
+```gherkin
+Given the following json text
+"""json
+{
+"key": "value"
+}
+"""
+```
+
+```scala
+Given("the following json text") { json: JsonText =>
+  // Do something with JsonText
+}
+```
+
+## DataTable to any
+
+`DataTableType` allows to transform DataTable to a custom type.
+
+This can be achieved in different ways:
+- transform lines with named headers to any type
+- transform lines without headers to any type
+- transform tables to any type
+- transform cells content to any type
+
+Note that DataTables in Gherkin can not represent `null` or the empty string unambiguously.
+Cucumber will interpret empty cells as `null`.
+But you can use a replacement to represent empty strings.
+See below.
+
+See also the [Datatable reference](https://github.com/cucumber/cucumber/tree/master/datatable).
+
+### Lines with named headers
+
+For instance, the following transformer can be defined:
+```scala
+case class Author(name: String, surname: String, famousBook: String)
+
+DataTableType { entry: Map[String, String] =>
+  Author(entry("name"), entry("surname"), entry("famousBook"))
+}
+```
+
+And used like this:
+```gherkin
+Given the following authors
+| name   | surname | famousBook      |
+| Alan   | Alou    | The Lion King   |
+| Robert | Bob     | Le Petit Prince |
+```
+
+```scala
+Given("the following authors") { (authors: java.util.List[Author]) =>
+  // Do something
+}
+
+// Or using DataTable
+Given("the following authors") { (table: DataTable) =>
+  val authors = table.asList[Author](classOf[Author])
+}
+```
+
+### Lines without headers
+
+For instance, the following transformer can be defined:
+```scala
+case class Author(name: String, surname: String, famousBook: String)
+
+DataTableType { row: Seq[String] =>
+  Author(row(0), row(1), row(2))
+}
+```
+
+And used like this:
+```gherkin
+Given the following authors
+| Alan   | Alou    | The Lion King   |
+| Robert | Bob     | Le Petit Prince |
+```
+
+```scala
+Given("the following authors") { (authors: java.util.List[Author]) =>
+  // Do something
+}
+
+// Or using DataTable
+Given("the following authors") { (table: DataTable) =>
+  val authors = table.asList[Author](classOf[Author])
+}
+```
+
+### DataTable
+
+For instance, the following transformer can be defined:
+```scala
+case class Author(name: String, surname: String, famousBook: String)
+case class GroupOfAuthor(authors: Seq[Author])
+
+DataTableType { table: DataTable =>
+  val authors = table.asMaps().asScala
+      .map(_.asScala)
+      .map(entry => Author(entry("name"), entry("surname"), entry("famousBook")))
+      .toSeq
+  GroupOfAuthor(authors)
+}
+```
+
+_Please note that the same transformation could be done using a line transformer._
+_The purpose of this transformer is to show the syntax._
+
+And used like this:
+```gherkin
+Given the following authors
+| name   | surname | famousBook      |
+| Alan   | Alou    | The Lion King   |
+| Robert | Bob     | Le Petit Prince |
+```
+
+```scala
+Given("the following authors") { (table: DataTable) =>
+  val authors = table.convert[GroupOfAuthor](classOf[GroupOfAuthor], false)
+}
+```
+
+### Cell
+
+For instance, the following transformer can be defined:
+```scala
+case class RichCell(content: String)
+
+DataTableType { cell: String =>
+  RichCell(cell)
+}
+```
+
+And used like this:
+```gherkin
+Given the following authors
+| Alan   | Alou    | The Lion King   |
+| Robert | Bob     | Le Petit Prince |
+```
+
+```scala
+Given("the following authors") { (authors: java.util.List[java.util.List[RichCell]]) =>
+  // Do something
+}
+
+// Or using DataTable
+Given("the following authors") { (table: DataTable) =>
+  val authors = table.asLists[RichCell](classOf[RichCell]))
+}
+```
+
+Or with headers like this:
+```gherkin
+Given the following authors
+| name   | surname | famousBook      |
+| Alan   | Alou    | The Lion King   |
+| Robert | Bob     | Le Petit Prince |
+```
+
+```scala
+Given("the following authors") { (authors: java.util.List[java.util.Map[String, RichCell]]) =>
+  // Do something
+}
+
+// Or using DataTable
+Given("the following authors") { (table: DataTable) =>
+  val authors = table.asMaps[String, RichCell](classOf[String], classOf[RichCell])
+}
+```
+
+### Empty values
+
+By default empty values in DataTable are treated as `null` by Cucumber.
+If you need to have empty values, you can define a replacement like `[empty]` that will be automatically replaced to empty when parsing DataTable.
+
+To do so, you can add a parameter to a `DataTableType` definition.
+
+For instance, with the following definition:
+```scala
+case class Author(name: String, surname: String, famousBook: String)
+
+DataTableType("[empty]") { (entry: Map[String, String]) =>
+  Author(entry("name"), entry("surname"), entry("famousBook"))
+}
+```
+
+And the following step:
+```gherkin
+Given the following authors
+| name    | surname | famousBook      |
+| Alan    | Alou    | The Lion King   |
+| [empty] | Bob     | Le Petit Prince |
+```
+
+You would actually get a list containing `Author("Alan", "Alou", "The Lion King")` and `Author("", "Bob", "Le Petit Prince")`.
+
+## Default transformers
+
+Default transformers are used when there is no specific transformer.
+
+They can be used with object mappers like Jackson to easily convert from well known strings to objects.
+
+### String
+
+For instance, the following definition:
+```scala
+DefaultParameterTransformer { (fromValue: String, toValueType: java.lang.Type) =>
+  // Apply logic to convert from String to toValueType
+}
+```
+
+Will be used to convert with such step definitions:
+```scala
+Given("A step with a undefined {} string") { (param: SomeType) =>
+  // The string between {} will be converted to SomeType
+}
+```
+
+### DataTable
+
+#### Lines with named headers
+
+For instance the following definition:
+```scala
+DefaultDataTableEntryTransformer("[empty]") { (fromValue: Map[String, String], toValueType: java.lang.Type) =>
+  // Apply some logic to convert from Map to toValueType
+}
+```
+
+Will be used to convert with such step definitions:
+```scala
+Given("A step with a datatable") { (rows: java.util.List[SomeType]) =>
+  // Do something
+}
+
+// Or DataTable
+Given("A step with a datatable") { (dataTable: DataTable) =>
+  val table = dataTable.asList[SomeType](classOf[SomeType])
+}
+```
+
+#### Cells
+
+For instance the following definition:
+```scala
+DefaultDataTableCellTransformer("[empty]") { (fromValue: String, toValueType: java.lang.Type) =>
+  // Apply some logic to convert from String to toValueType
+}
+```
+
+Will be used to convert with such step definitions:
+```scala
+Given("A step with a datatable") { (rows: java.util.List[java.util.List[SomeType]]) =>
+  // Do something
+}
+
+// Or DataTable
+Given("A step with a datatable") { (dataTable: DataTable) =>
+  val table = dataTable.asLists[SomeType](classOf[SomeType])
+}
+```

--- a/docs/upgrade_v5.md
+++ b/docs/upgrade_v5.md
@@ -52,6 +52,12 @@ Before { _ =>
 
 See also the [Hooks documentation](hooks.md).
 
+## Transformers
+
+If you are using transformers defined with `TypeRegistryConfigurer`, please note that this is now deprecated in Cucumber Core.
+
+The recommended way to define transformers is to define them in glue code. See [Transformers](./transformers.md).
+
 ## Under the hood
 
 ### Instantiate glue classes per scenario

--- a/scala/sources/gen.scala
+++ b/scala/sources/gen.scala
@@ -13,3 +13,25 @@ for (i <- 1 to 22) {
 
   println(p1 + p2 + " = { " + register + pf + closeRegister + "\n")
 }
+
+/*
+ * Generates the apply methods in ParameterTypeDsl for Function1 to Function22
+ */
+for (i <- 1 to 22) {
+  // String, String, ..., String
+  val types = (1 to i).map(_ => "String").mkString(", ")
+  // p1, p2, ..., p22
+  val args = (1 to i).map(j => s"p$j").mkString(", ")
+
+  val template =
+    s"""
+      |def apply[R](f: ($types) => R)(implicit tag: ClassTag[R]): Unit = {
+      |  register {
+      |    case List($args) =>
+      |       f($args)
+      |  }
+      |}
+      |""".stripMargin
+
+  println(template)
+}

--- a/scala/sources/src/main/scala/io/cucumber/scala/AbstractDatatableElementTransformerDefinition.scala
+++ b/scala/sources/src/main/scala/io/cucumber/scala/AbstractDatatableElementTransformerDefinition.scala
@@ -1,0 +1,60 @@
+package io.cucumber.scala
+
+import io.cucumber.datatable.DataTable
+
+import scala.util.{Failure, Success, Try}
+import scala.collection.JavaConverters._
+
+trait AbstractDatatableElementTransformerDefinition extends AbstractGlueDefinition {
+
+  val emptyPatterns: Seq[String]
+
+  protected def replaceEmptyPatternsWithEmptyString(row: Seq[String]): Seq[String] = {
+    row.map(replaceEmptyPatternsWithEmptyString)
+  }
+
+  protected def replaceEmptyPatternsWithEmptyString(table: DataTable): DataTable = {
+    val rawWithEmptyStrings = table.cells().asScala
+      .map(_.asScala.toSeq)
+      .map(replaceEmptyPatternsWithEmptyString)
+      .map(_.asJava)
+      .toSeq
+      .asJava
+
+    DataTable.create(rawWithEmptyStrings, table.getTableConverter)
+  }
+
+  protected def replaceEmptyPatternsWithEmptyString(fromValue: Map[String, String]): Try[Map[String, String]] = {
+    val replacement = fromValue.toSeq.map { case (key, value) =>
+      val potentiallyEmptyKey = replaceEmptyPatternsWithEmptyString(key)
+      val potentiallyEmptyValue = replaceEmptyPatternsWithEmptyString(value)
+
+      (potentiallyEmptyKey, potentiallyEmptyValue)
+    }
+
+    if (containsDuplicateKey(replacement)) {
+      Failure(createDuplicateKeyAfterReplacement(fromValue))
+    } else {
+      Success(replacement.toMap)
+    }
+  }
+
+  protected def replaceEmptyPatternsWithEmptyString(t: String): String = {
+    if (emptyPatterns.contains(t)) {
+      ""
+    } else {
+      t
+    }
+  }
+
+  private def containsDuplicateKey(seq: Seq[(String, Any)]): Boolean = {
+    seq.map { case (key, _) => key }.toSet.size != seq.size
+  }
+
+  private def createDuplicateKeyAfterReplacement(fromValue: Map[String, String]): IllegalArgumentException = {
+    val conflict = emptyPatterns.filter(emptyPattern => fromValue.contains(emptyPattern))
+    val msg = s"After replacing ${conflict.headOption.getOrElse("")} and ${conflict.drop(1).headOption.getOrElse("")} with empty strings the datatable entry contains duplicate keys: $fromValue"
+    new IllegalArgumentException(msg)
+  }
+
+}

--- a/scala/sources/src/main/scala/io/cucumber/scala/Aliases.scala
+++ b/scala/sources/src/main/scala/io/cucumber/scala/Aliases.scala
@@ -9,4 +9,6 @@ object Aliases {
 
   type StepDefinitionBody = () => Unit
 
+  type DocStringDefinitionBody[T] = String => T
+
 }

--- a/scala/sources/src/main/scala/io/cucumber/scala/Aliases.scala
+++ b/scala/sources/src/main/scala/io/cucumber/scala/Aliases.scala
@@ -11,4 +11,10 @@ object Aliases {
 
   type DocStringDefinitionBody[T] = String => T
 
+  type DefaultParameterTransformerBody = (String, java.lang.reflect.Type) => AnyRef
+
+  type DefaultDataTableCellTransformerBody = (String, java.lang.reflect.Type) => AnyRef
+
+  type DefaultDataTableEntryTransformerBody = (Map[String, String], java.lang.reflect.Type) => AnyRef
+
 }

--- a/scala/sources/src/main/scala/io/cucumber/scala/DataTableDefinitionBody.scala
+++ b/scala/sources/src/main/scala/io/cucumber/scala/DataTableDefinitionBody.scala
@@ -1,0 +1,59 @@
+package io.cucumber.scala
+
+import io.cucumber.datatable.DataTable
+
+trait DataTableEntryDefinitionBody[T] {
+
+  def transform(entry: Map[String, String]): T
+
+}
+
+trait DataTableRowDefinitionBody[T] {
+
+  def transform(row: Seq[String]): T
+
+}
+
+trait DataTableCellDefinitionBody[T] {
+
+  def transform(cell: String): T
+
+}
+
+trait DataTableDefinitionBody[T] {
+
+  def transform(dataTable: DataTable): T
+
+}
+
+object DataTableEntryDefinitionBody {
+
+  implicit def function1AsDataTableEntryDefinitionBody[T](f: (Map[String, String]) => T): DataTableEntryDefinitionBody[T] = new DataTableEntryDefinitionBody[T] {
+    override def transform(entry: Map[String, String]): T = f.apply(entry)
+  }
+
+}
+
+object DataTableRowDefinitionBody {
+
+  implicit def function1AsDataTableRowDefinitionBody[T](f: (Seq[String]) => T): DataTableRowDefinitionBody[T] = new DataTableRowDefinitionBody[T] {
+    override def transform(row: Seq[String]): T = f.apply(row)
+  }
+
+}
+
+object DataTableCellDefinitionBody {
+
+  implicit def function1AsDataTableCellDefinitionBody[T](f: (String) => T): DataTableCellDefinitionBody[T] = new DataTableCellDefinitionBody[T] {
+    override def transform(cell: String): T = f.apply(cell)
+  }
+
+}
+
+object DataTableDefinitionBody {
+
+  implicit def function1AsDataTableDefinitionBody[T](f: (DataTable) => T): DataTableDefinitionBody[T] = new DataTableDefinitionBody[T] {
+    override def transform(dataTable: DataTable): T = f.apply(dataTable)
+  }
+
+}

--- a/scala/sources/src/main/scala/io/cucumber/scala/GlueAdaptor.scala
+++ b/scala/sources/src/main/scala/io/cucumber/scala/GlueAdaptor.scala
@@ -19,6 +19,9 @@ class GlueAdaptor(glue: Glue) {
     registry.docStringTypes.map(ScalaDocStringTypeDefinition(_, scenarioScoped)).foreach(glue.addDocStringType)
     registry.dataTableTypes.map(ScalaDataTableTypeDefinition(_, scenarioScoped)).foreach(glue.addDataTableType)
     registry.parameterTypes.map(ScalaParameterTypeDefinition(_, scenarioScoped)).foreach(glue.addParameterType)
+    registry.defaultParameterTransformers.map(ScalaDefaultParameterTransformerDefinition(_, scenarioScoped)).foreach(glue.addDefaultParameterTransformer)
+    registry.defaultDataTableCellTransformers.map(ScalaDefaultDataTableCellTransformerDefinition(_, scenarioScoped)).foreach(glue.addDefaultDataTableCellTransformer)
+    registry.defaultDataTableEntryTransformers.map(ScalaDefaultDataTableEntryTransformerDefinition(_, scenarioScoped)).foreach(glue.addDefaultDataTableEntryTransformer)
   }
 
 }

--- a/scala/sources/src/main/scala/io/cucumber/scala/GlueAdaptor.scala
+++ b/scala/sources/src/main/scala/io/cucumber/scala/GlueAdaptor.scala
@@ -16,6 +16,8 @@ class GlueAdaptor(glue: Glue) {
     registry.afterHooks.map(ScalaHookDefinition(_, scenarioScoped)).foreach(glue.addAfterHook)
     registry.afterStepHooks.map(ScalaHookDefinition(_, scenarioScoped)).foreach(glue.addAfterStepHook)
     registry.beforeStepHooks.map(ScalaHookDefinition(_, scenarioScoped)).foreach(glue.addBeforeStepHook)
+    registry.docStringTypes.map(ScalaDocStringTypeDefinition(_, scenarioScoped)).foreach(glue.addDocStringType)
+    registry.dataTableTypes.map(ScalaDataTableTypeDefinition(_, scenarioScoped)).foreach(glue.addDataTableType)
   }
 
 }

--- a/scala/sources/src/main/scala/io/cucumber/scala/GlueAdaptor.scala
+++ b/scala/sources/src/main/scala/io/cucumber/scala/GlueAdaptor.scala
@@ -18,6 +18,7 @@ class GlueAdaptor(glue: Glue) {
     registry.beforeStepHooks.map(ScalaHookDefinition(_, scenarioScoped)).foreach(glue.addBeforeStepHook)
     registry.docStringTypes.map(ScalaDocStringTypeDefinition(_, scenarioScoped)).foreach(glue.addDocStringType)
     registry.dataTableTypes.map(ScalaDataTableTypeDefinition(_, scenarioScoped)).foreach(glue.addDataTableType)
+    registry.parameterTypes.map(ScalaParameterTypeDefinition(_, scenarioScoped)).foreach(glue.addParameterType)
   }
 
 }

--- a/scala/sources/src/main/scala/io/cucumber/scala/ScalaDataTableCellDefinition.scala
+++ b/scala/sources/src/main/scala/io/cucumber/scala/ScalaDataTableCellDefinition.scala
@@ -1,0 +1,28 @@
+package io.cucumber.scala
+
+import io.cucumber.core.backend.ScenarioScoped
+import io.cucumber.datatable.{DataTableType, TableCellTransformer}
+
+trait ScalaDataTableCellDefinition[T] extends ScalaDataTableTypeDefinition {
+
+  val details: ScalaDataTableCellTypeDetails[T]
+
+  override val emptyPatterns: Seq[String] = details.emptyPatterns
+
+  override val location: StackTraceElement = new Exception().getStackTrace()(3)
+
+  private val transformer: TableCellTransformer[T] = new TableCellTransformer[T] {
+    override def transform(cell: String): T = {
+      details.body.transform(replaceEmptyPatternsWithEmptyString(cell))
+    }
+  }
+
+  override val dataTableType = new DataTableType(details.tag.runtimeClass, transformer)
+
+}
+
+class ScalaScenarioScopedDataTableCellDefinition[T](override val details: ScalaDataTableCellTypeDetails[T]) extends ScalaDataTableCellDefinition[T] with ScenarioScoped {
+}
+
+class ScalaGlobalDataTableCellDefinition[T](override val details: ScalaDataTableCellTypeDetails[T]) extends ScalaDataTableCellDefinition[T] {
+}

--- a/scala/sources/src/main/scala/io/cucumber/scala/ScalaDataTableDefinition.scala
+++ b/scala/sources/src/main/scala/io/cucumber/scala/ScalaDataTableDefinition.scala
@@ -1,0 +1,28 @@
+package io.cucumber.scala
+
+import io.cucumber.core.backend.ScenarioScoped
+import io.cucumber.datatable.{DataTable, DataTableType, TableTransformer}
+
+trait ScalaDataTableDefinition[T] extends ScalaDataTableTypeDefinition {
+
+  val details: ScalaDataTableTableTypeDetails[T]
+
+  override val emptyPatterns: Seq[String] = details.emptyPatterns
+
+  override val location: StackTraceElement = new Exception().getStackTrace()(3)
+
+  private val transformer: TableTransformer[T] = new TableTransformer[T] {
+    override def transform(table: DataTable): T = {
+      details.body.transform(replaceEmptyPatternsWithEmptyString(table))
+    }
+  }
+
+  override val dataTableType = new DataTableType(details.tag.runtimeClass, transformer)
+
+}
+
+class ScalaScenarioScopedDataTableDefinition[T](override val details: ScalaDataTableTableTypeDetails[T]) extends ScalaDataTableDefinition[T] with ScenarioScoped {
+}
+
+class ScalaGlobalDataTableDefinition[T](override val details: ScalaDataTableTableTypeDetails[T]) extends ScalaDataTableDefinition[T] {
+}

--- a/scala/sources/src/main/scala/io/cucumber/scala/ScalaDataTableEntryDefinition.scala
+++ b/scala/sources/src/main/scala/io/cucumber/scala/ScalaDataTableEntryDefinition.scala
@@ -1,0 +1,34 @@
+package io.cucumber.scala
+
+import java.util.{Map => JavaMap}
+
+import io.cucumber.core.backend.ScenarioScoped
+import io.cucumber.datatable.{DataTableType, TableEntryTransformer}
+
+import scala.collection.JavaConverters._
+
+trait ScalaDataTableEntryDefinition[T] extends ScalaDataTableTypeDefinition {
+
+  val details: ScalaDataTableEntryTypeDetails[T]
+
+  override val emptyPatterns: Seq[String] = details.emptyPatterns
+
+  override val location: StackTraceElement = new Exception().getStackTrace()(3)
+
+  private val transformer: TableEntryTransformer[T] = new TableEntryTransformer[T] {
+    override def transform(entry: JavaMap[String, String]): T = {
+      replaceEmptyPatternsWithEmptyString(entry.asScala.toMap)
+        .map(details.body.transform)
+        .get
+    }
+  }
+
+  override val dataTableType = new DataTableType(details.tag.runtimeClass, transformer)
+
+}
+
+class ScalaScenarioScopedDataTableEntryDefinition[T](override val details: ScalaDataTableEntryTypeDetails[T]) extends ScalaDataTableEntryDefinition[T] with ScenarioScoped {
+}
+
+class ScalaGlobalDataTableEntryDefinition[T](override val details: ScalaDataTableEntryTypeDetails[T]) extends ScalaDataTableEntryDefinition[T] {
+}

--- a/scala/sources/src/main/scala/io/cucumber/scala/ScalaDataTableRowDefinition.scala
+++ b/scala/sources/src/main/scala/io/cucumber/scala/ScalaDataTableRowDefinition.scala
@@ -1,0 +1,32 @@
+package io.cucumber.scala
+
+import java.util.{List => JavaList}
+
+import io.cucumber.core.backend.ScenarioScoped
+import io.cucumber.datatable.{DataTableType, TableRowTransformer}
+
+import scala.collection.JavaConverters._
+
+trait ScalaDataTableRowDefinition[T] extends ScalaDataTableTypeDefinition {
+
+  val details: ScalaDataTableRowTypeDetails[T]
+
+  override val emptyPatterns: Seq[String] = details.emptyPatterns
+
+  override val location: StackTraceElement = new Exception().getStackTrace()(3)
+
+  private val transformer: TableRowTransformer[T] = new TableRowTransformer[T] {
+    override def transform(row: JavaList[String]): T = {
+      details.body.transform(replaceEmptyPatternsWithEmptyString(row.asScala.toSeq))
+    }
+  }
+
+  override val dataTableType = new DataTableType(details.tag.runtimeClass, transformer)
+
+}
+
+class ScalaScenarioScopedDataTableRowDefinition[T](override val details: ScalaDataTableRowTypeDetails[T]) extends ScalaDataTableRowDefinition[T] with ScenarioScoped {
+}
+
+class ScalaGlobalDataTableRowDefinition[T](override val details: ScalaDataTableRowTypeDetails[T]) extends ScalaDataTableRowDefinition[T] {
+}

--- a/scala/sources/src/main/scala/io/cucumber/scala/ScalaDataTableTypeDefinition.scala
+++ b/scala/sources/src/main/scala/io/cucumber/scala/ScalaDataTableTypeDefinition.scala
@@ -1,0 +1,42 @@
+package io.cucumber.scala
+
+import io.cucumber.core.backend.DataTableTypeDefinition
+
+trait ScalaDataTableTypeDefinition
+  extends DataTableTypeDefinition
+    with AbstractDatatableElementTransformerDefinition {
+
+}
+
+object ScalaDataTableTypeDefinition {
+
+  def apply[T](details: ScalaDataTableTypeDetails[T], scenarioScoped: Boolean): ScalaDataTableTypeDefinition = {
+    details match {
+      case entryDetails@ScalaDataTableEntryTypeDetails(_, _, _) =>
+        if (scenarioScoped) {
+          new ScalaScenarioScopedDataTableEntryDefinition[T](entryDetails)
+        } else {
+          new ScalaGlobalDataTableEntryDefinition[T](entryDetails)
+        }
+      case rowDetails@ScalaDataTableRowTypeDetails(_, _, _) =>
+        if (scenarioScoped) {
+          new ScalaScenarioScopedDataTableRowDefinition[T](rowDetails)
+        } else {
+          new ScalaGlobalDataTableRowDefinition[T](rowDetails)
+        }
+      case rowDetails@ScalaDataTableCellTypeDetails(_, _, _) =>
+        if (scenarioScoped) {
+          new ScalaScenarioScopedDataTableCellDefinition[T](rowDetails)
+        } else {
+          new ScalaGlobalDataTableCellDefinition[T](rowDetails)
+        }
+      case rowDetails@ScalaDataTableTableTypeDetails(_, _, _) =>
+        if (scenarioScoped) {
+          new ScalaScenarioScopedDataTableDefinition[T](rowDetails)
+        } else {
+          new ScalaGlobalDataTableDefinition[T](rowDetails)
+        }
+    }
+  }
+
+}

--- a/scala/sources/src/main/scala/io/cucumber/scala/ScalaDataTableTypeDetails.scala
+++ b/scala/sources/src/main/scala/io/cucumber/scala/ScalaDataTableTypeDetails.scala
@@ -1,0 +1,14 @@
+package io.cucumber.scala
+
+import scala.reflect.ClassTag
+
+sealed trait ScalaDataTableTypeDetails[T]
+
+case class ScalaDataTableEntryTypeDetails[T](emptyPatterns: Seq[String], body: DataTableEntryDefinitionBody[T], tag: ClassTag[T]) extends ScalaDataTableTypeDetails[T]
+
+case class ScalaDataTableRowTypeDetails[T](emptyPatterns: Seq[String], body: DataTableRowDefinitionBody[T], tag: ClassTag[T]) extends ScalaDataTableTypeDetails[T]
+
+case class ScalaDataTableCellTypeDetails[T](emptyPatterns: Seq[String], body: DataTableCellDefinitionBody[T], tag: ClassTag[T]) extends ScalaDataTableTypeDetails[T]
+
+case class ScalaDataTableTableTypeDetails[T](emptyPatterns: Seq[String], body: DataTableDefinitionBody[T], tag: ClassTag[T]) extends ScalaDataTableTypeDetails[T]
+

--- a/scala/sources/src/main/scala/io/cucumber/scala/ScalaDefaultDataTableCellTransformerDefinition.scala
+++ b/scala/sources/src/main/scala/io/cucumber/scala/ScalaDefaultDataTableCellTransformerDefinition.scala
@@ -1,0 +1,40 @@
+package io.cucumber.scala
+
+import java.lang.reflect.Type
+
+import io.cucumber.core.backend.{DefaultDataTableCellTransformerDefinition, ScenarioScoped}
+import io.cucumber.datatable.TableCellByTypeTransformer
+
+trait ScalaDefaultDataTableCellTransformerDefinition extends DefaultDataTableCellTransformerDefinition with AbstractDatatableElementTransformerDefinition {
+
+  val details: ScalaDefaultDataTableCellTransformerDetails
+
+  override val emptyPatterns: Seq[String] = details.emptyPatterns
+
+  override val location: StackTraceElement = new Exception().getStackTrace()(3)
+
+  override val tableCellByTypeTransformer: TableCellByTypeTransformer = new TableCellByTypeTransformer {
+    override def transform(fromValue: String, toTypeValue: Type): AnyRef = {
+      details.body.apply(replaceEmptyPatternsWithEmptyString(fromValue), toTypeValue)
+    }
+  }
+
+}
+
+object ScalaDefaultDataTableCellTransformerDefinition {
+
+  def apply(details: ScalaDefaultDataTableCellTransformerDetails, scenarioScoped: Boolean): ScalaDefaultDataTableCellTransformerDefinition = {
+    if (scenarioScoped) {
+      new ScalaScenarioScopedDataTableCellTransformerDefinition(details)
+    } else {
+      new ScalaGlobalDataTableCellTransformerDefinition(details)
+    }
+  }
+
+}
+
+class ScalaScenarioScopedDataTableCellTransformerDefinition(override val details: ScalaDefaultDataTableCellTransformerDetails) extends ScalaDefaultDataTableCellTransformerDefinition with ScenarioScoped {
+}
+
+class ScalaGlobalDataTableCellTransformerDefinition(override val details: ScalaDefaultDataTableCellTransformerDetails) extends ScalaDefaultDataTableCellTransformerDefinition {
+}

--- a/scala/sources/src/main/scala/io/cucumber/scala/ScalaDefaultDataTableEntryTransformerDefinition.scala
+++ b/scala/sources/src/main/scala/io/cucumber/scala/ScalaDefaultDataTableEntryTransformerDefinition.scala
@@ -1,0 +1,47 @@
+package io.cucumber.scala
+
+import java.lang.reflect.Type
+import java.util.{Map => JavaMap}
+
+import io.cucumber.core.backend.{DefaultDataTableEntryTransformerDefinition, ScenarioScoped}
+import io.cucumber.datatable.{TableCellByTypeTransformer, TableEntryByTypeTransformer}
+
+import scala.collection.JavaConverters._
+
+trait ScalaDefaultDataTableEntryTransformerDefinition extends DefaultDataTableEntryTransformerDefinition with AbstractDatatableElementTransformerDefinition {
+
+  val details: ScalaDefaultDataTableEntryTransformerDetails
+
+  override val emptyPatterns: Seq[String] = details.emptyPatterns
+
+  override val location: StackTraceElement = new Exception().getStackTrace()(3)
+
+  override val tableEntryByTypeTransformer: TableEntryByTypeTransformer = new TableEntryByTypeTransformer {
+    override def transform(fromValue: JavaMap[String, String], toValueType: Type, tableCellByTypeTransformer: TableCellByTypeTransformer): AnyRef = {
+      replaceEmptyPatternsWithEmptyString(fromValue.asScala.toMap)
+        .map(details.body.apply(_, toValueType))
+        .get
+    }
+  }
+
+  override val headersToProperties: Boolean = true
+
+}
+
+object ScalaDefaultDataTableEntryTransformerDefinition {
+
+  def apply(details: ScalaDefaultDataTableEntryTransformerDetails, scenarioScoped: Boolean): ScalaDefaultDataTableEntryTransformerDefinition = {
+    if (scenarioScoped) {
+      new ScalaScenarioScopedDataTableEntryTransformerDefinition(details)
+    } else {
+      new ScalaGlobalDataTableEntryTransformerDefinition(details)
+    }
+  }
+
+}
+
+class ScalaScenarioScopedDataTableEntryTransformerDefinition(override val details: ScalaDefaultDataTableEntryTransformerDetails) extends ScalaDefaultDataTableEntryTransformerDefinition with ScenarioScoped {
+}
+
+class ScalaGlobalDataTableEntryTransformerDefinition(override val details: ScalaDefaultDataTableEntryTransformerDetails) extends ScalaDefaultDataTableEntryTransformerDefinition {
+}

--- a/scala/sources/src/main/scala/io/cucumber/scala/ScalaDefaultParameterTransformerDefinition.scala
+++ b/scala/sources/src/main/scala/io/cucumber/scala/ScalaDefaultParameterTransformerDefinition.scala
@@ -1,0 +1,38 @@
+package io.cucumber.scala
+
+import java.lang.reflect.Type
+
+import io.cucumber.core.backend.{DefaultParameterTransformerDefinition, ScenarioScoped}
+import io.cucumber.cucumberexpressions.ParameterByTypeTransformer
+
+trait ScalaDefaultParameterTransformerDefinition extends DefaultParameterTransformerDefinition with AbstractGlueDefinition {
+
+  val details: ScalaDefaultParameterTransformerDetails
+
+  override val location: StackTraceElement = new Exception().getStackTrace()(3)
+
+  override val parameterByTypeTransformer: ParameterByTypeTransformer = new ParameterByTypeTransformer {
+    override def transform(fromValue: String, toValue: Type): AnyRef = {
+      details.body.apply(fromValue, toValue)
+    }
+  }
+
+}
+
+object ScalaDefaultParameterTransformerDefinition {
+
+  def apply(details: ScalaDefaultParameterTransformerDetails, scenarioScoped: Boolean): ScalaDefaultParameterTransformerDefinition = {
+    if (scenarioScoped) {
+      new ScalaScenarioScopedDefaultParameterTransformerDefinition(details)
+    } else {
+      new ScalaGlobalDefaultParameterTransformerDefinition(details)
+    }
+  }
+
+}
+
+class ScalaScenarioScopedDefaultParameterTransformerDefinition(override val details: ScalaDefaultParameterTransformerDetails) extends ScalaDefaultParameterTransformerDefinition with ScenarioScoped {
+}
+
+class ScalaGlobalDefaultParameterTransformerDefinition(override val details: ScalaDefaultParameterTransformerDetails) extends ScalaDefaultParameterTransformerDefinition {
+}

--- a/scala/sources/src/main/scala/io/cucumber/scala/ScalaDefaultTransformerDetails.scala
+++ b/scala/sources/src/main/scala/io/cucumber/scala/ScalaDefaultTransformerDetails.scala
@@ -1,0 +1,9 @@
+package io.cucumber.scala
+
+import io.cucumber.scala.Aliases.{DefaultDataTableCellTransformerBody, DefaultDataTableEntryTransformerBody, DefaultParameterTransformerBody}
+
+case class ScalaDefaultParameterTransformerDetails(body: DefaultParameterTransformerBody)
+
+case class ScalaDefaultDataTableCellTransformerDetails(emptyPatterns: Seq[String], body: DefaultDataTableCellTransformerBody)
+
+case class ScalaDefaultDataTableEntryTransformerDetails(emptyPatterns: Seq[String], body: DefaultDataTableEntryTransformerBody)

--- a/scala/sources/src/main/scala/io/cucumber/scala/ScalaDocStringTypeDefinition.scala
+++ b/scala/sources/src/main/scala/io/cucumber/scala/ScalaDocStringTypeDefinition.scala
@@ -1,0 +1,50 @@
+package io.cucumber.scala
+
+import io.cucumber.core.backend.{DocStringTypeDefinition, ScenarioScoped}
+import io.cucumber.docstring.DocStringType
+import io.cucumber.docstring.DocStringType.Transformer
+
+import scala.reflect.ClassTag
+
+trait ScalaDocStringTypeDefinition[T]
+  extends DocStringTypeDefinition
+    with AbstractGlueDefinition {
+
+  val details: ScalaDocStringTypeDetails[T]
+
+  implicit val ev: ClassTag[T]
+
+  override val location: StackTraceElement = new Exception().getStackTrace()(3)
+
+  private val transformer: Transformer[T] = new Transformer[T] {
+    override def transform(s: String): T = {
+      details.body.apply(s)
+    }
+  }
+
+  override val docStringType: DocStringType = new DocStringType(ev.runtimeClass, details.contentType, transformer)
+
+}
+
+object ScalaDocStringTypeDefinition {
+
+  def apply[T](details: ScalaDocStringTypeDetails[T], scenarioScoped: Boolean): ScalaDocStringTypeDefinition[T] = {
+    if (scenarioScoped) {
+      new ScalaScenarioScopedDocStringTypeDefinition(details)(details.tag)
+    } else {
+      new ScalaGlobalDocStringTypeDefinition(details)(details.tag)
+    }
+  }
+
+}
+
+class ScalaScenarioScopedDocStringTypeDefinition[T](override val details: ScalaDocStringTypeDetails[T])
+                                                   (implicit val ev: ClassTag[T])
+  extends ScalaDocStringTypeDefinition[T]
+    with ScenarioScoped {
+}
+
+class ScalaGlobalDocStringTypeDefinition[T](override val details: ScalaDocStringTypeDetails[T])
+                                           (implicit val ev: ClassTag[T])
+  extends ScalaDocStringTypeDefinition[T] {
+}

--- a/scala/sources/src/main/scala/io/cucumber/scala/ScalaDocStringTypeDetails.scala
+++ b/scala/sources/src/main/scala/io/cucumber/scala/ScalaDocStringTypeDetails.scala
@@ -1,0 +1,7 @@
+package io.cucumber.scala
+
+import io.cucumber.scala.Aliases.DocStringDefinitionBody
+
+import scala.reflect.ClassTag
+
+case class ScalaDocStringTypeDetails[T](contentType: String, body: DocStringDefinitionBody[T], tag: ClassTag[T])

--- a/scala/sources/src/main/scala/io/cucumber/scala/ScalaDsl.scala
+++ b/scala/sources/src/main/scala/io/cucumber/scala/ScalaDsl.scala
@@ -6,11 +6,7 @@ import io.cucumber.scala.Aliases.{DocStringDefinitionBody, HookBody}
 
 import scala.reflect.ClassTag
 
-/**
- * Base trait for a scala step definition implementation.
- */
-trait ScalaDsl {
-  self =>
+private[scala] trait BaseScalaDsl {
 
   val NO_REPLACEMENT = Seq[String]()
   val EMPTY_TAG_EXPRESSION = ""
@@ -20,6 +16,17 @@ trait ScalaDsl {
   import scala.language.implicitConversions
 
   private[scala] val registry: ScalaDslRegistry = new ScalaDslRegistry()
+
+}
+
+/**
+ * Base trait for a scala step definition implementation.
+ */
+trait ScalaDsl extends BaseScalaDsl with StepDsl with HookDsl with DataTableTypeDsl with DocStringTypeDsl {
+
+}
+
+private[scala] trait HookDsl extends BaseScalaDsl {
 
   // TODO support Before/After with no parameter
 
@@ -87,9 +94,17 @@ trait ScalaDsl {
     registry.afterStepHooks += ScalaHookDetails(tagExpression, order, body)
   }
 
+}
+
+private[scala] trait DocStringTypeDsl extends BaseScalaDsl {
+
   def DocStringType[T](contentType: String)(body: DocStringDefinitionBody[T])(implicit ev: ClassTag[T]): Unit = {
     registry.docStringTypes += ScalaDocStringTypeDetails[T](contentType, body, ev)
   }
+
+}
+
+private[scala] trait DataTableTypeDsl extends BaseScalaDsl {
 
   def DataTableType: DataTableTypeBody = DataTableType(NO_REPLACEMENT)
 
@@ -117,6 +132,10 @@ trait ScalaDsl {
 
   }
 
+}
+
+private[scala] trait StepDsl extends BaseScalaDsl {
+  self =>
 
   final class Step(name: String) {
     def apply(regex: String): StepBody = new StepBody(name, regex)
@@ -572,3 +591,4 @@ trait ScalaDsl {
   }
 
 }
+

--- a/scala/sources/src/main/scala/io/cucumber/scala/ScalaDsl.scala
+++ b/scala/sources/src/main/scala/io/cucumber/scala/ScalaDsl.scala
@@ -22,7 +22,7 @@ private[scala] trait BaseScalaDsl {
 /**
  * Base trait for a scala step definition implementation.
  */
-trait ScalaDsl extends BaseScalaDsl with StepDsl with HookDsl with DataTableTypeDsl with DocStringTypeDsl {
+trait ScalaDsl extends BaseScalaDsl with StepDsl with HookDsl with DataTableTypeDsl with DocStringTypeDsl with ParameterTypeDsl {
 
 }
 
@@ -128,6 +128,176 @@ private[scala] trait DataTableTypeDsl extends BaseScalaDsl {
 
     def apply[T](body: DataTableDefinitionBody[T])(implicit ev: ClassTag[T]): Unit = {
       registry.dataTableTypes += ScalaDataTableTableTypeDetails[T](replaceWithEmptyString, body, ev)
+    }
+
+  }
+
+}
+
+private[scala] trait ParameterTypeDsl extends BaseScalaDsl {
+
+  def ParameterType(name: String, regex: String) = new ParameterTypeBody(name, regex)
+
+  final class ParameterTypeBody(name: String, regex: String) {
+
+    // Important: use the piece of code in the file gen.scala to generate these methods easily
+
+    def apply[R](f: (String) => R)(implicit tag: ClassTag[R]): Unit = {
+      register {
+        case List(p1) =>
+          f(p1)
+      }
+    }
+
+    def apply[R](f: (String, String) => R)(implicit tag: ClassTag[R]): Unit = {
+      register {
+        case List(p1, p2) =>
+          f(p1, p2)
+      }
+    }
+
+    def apply[R](f: (String, String, String) => R)(implicit tag: ClassTag[R]): Unit = {
+      register {
+        case List(p1, p2, p3) =>
+          f(p1, p2, p3)
+      }
+    }
+
+    def apply[R](f: (String, String, String, String) => R)(implicit tag: ClassTag[R]): Unit = {
+      register {
+        case List(p1, p2, p3, p4) =>
+          f(p1, p2, p3, p4)
+      }
+    }
+
+    def apply[R](f: (String, String, String, String, String) => R)(implicit tag: ClassTag[R]): Unit = {
+      register {
+        case List(p1, p2, p3, p4, p5) =>
+          f(p1, p2, p3, p4, p5)
+      }
+    }
+
+    def apply[R](f: (String, String, String, String, String, String) => R)(implicit tag: ClassTag[R]): Unit = {
+      register {
+        case List(p1, p2, p3, p4, p5, p6) =>
+          f(p1, p2, p3, p4, p5, p6)
+      }
+    }
+
+    def apply[R](f: (String, String, String, String, String, String, String) => R)(implicit tag: ClassTag[R]): Unit = {
+      register {
+        case List(p1, p2, p3, p4, p5, p6, p7) =>
+          f(p1, p2, p3, p4, p5, p6, p7)
+      }
+    }
+
+    def apply[R](f: (String, String, String, String, String, String, String, String) => R)(implicit tag: ClassTag[R]): Unit = {
+      register {
+        case List(p1, p2, p3, p4, p5, p6, p7, p8) =>
+          f(p1, p2, p3, p4, p5, p6, p7, p8)
+      }
+    }
+
+    def apply[R](f: (String, String, String, String, String, String, String, String, String) => R)(implicit tag: ClassTag[R]): Unit = {
+      register {
+        case List(p1, p2, p3, p4, p5, p6, p7, p8, p9) =>
+          f(p1, p2, p3, p4, p5, p6, p7, p8, p9)
+      }
+    }
+
+    def apply[R](f: (String, String, String, String, String, String, String, String, String, String) => R)(implicit tag: ClassTag[R]): Unit = {
+      register {
+        case List(p1, p2, p3, p4, p5, p6, p7, p8, p9, p10) =>
+          f(p1, p2, p3, p4, p5, p6, p7, p8, p9, p10)
+      }
+    }
+
+    def apply[R](f: (String, String, String, String, String, String, String, String, String, String, String) => R)(implicit tag: ClassTag[R]): Unit = {
+      register {
+        case List(p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11) =>
+          f(p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11)
+      }
+    }
+
+    def apply[R](f: (String, String, String, String, String, String, String, String, String, String, String, String) => R)(implicit tag: ClassTag[R]): Unit = {
+      register {
+        case List(p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12) =>
+          f(p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12)
+      }
+    }
+
+    def apply[R](f: (String, String, String, String, String, String, String, String, String, String, String, String, String) => R)(implicit tag: ClassTag[R]): Unit = {
+      register {
+        case List(p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13) =>
+          f(p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13)
+      }
+    }
+
+    def apply[R](f: (String, String, String, String, String, String, String, String, String, String, String, String, String, String) => R)(implicit tag: ClassTag[R]): Unit = {
+      register {
+        case List(p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, p14) =>
+          f(p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, p14)
+      }
+    }
+
+    def apply[R](f: (String, String, String, String, String, String, String, String, String, String, String, String, String, String, String) => R)(implicit tag: ClassTag[R]): Unit = {
+      register {
+        case List(p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, p14, p15) =>
+          f(p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, p14, p15)
+      }
+    }
+
+    def apply[R](f: (String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String) => R)(implicit tag: ClassTag[R]): Unit = {
+      register {
+        case List(p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, p14, p15, p16) =>
+          f(p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, p14, p15, p16)
+      }
+    }
+
+    def apply[R](f: (String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String) => R)(implicit tag: ClassTag[R]): Unit = {
+      register {
+        case List(p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, p14, p15, p16, p17) =>
+          f(p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, p14, p15, p16, p17)
+      }
+    }
+
+    def apply[R](f: (String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String) => R)(implicit tag: ClassTag[R]): Unit = {
+      register {
+        case List(p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, p14, p15, p16, p17, p18) =>
+          f(p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, p14, p15, p16, p17, p18)
+      }
+    }
+
+    def apply[R](f: (String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String) => R)(implicit tag: ClassTag[R]): Unit = {
+      register {
+        case List(p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, p14, p15, p16, p17, p18, p19) =>
+          f(p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, p14, p15, p16, p17, p18, p19)
+      }
+    }
+
+    def apply[R](f: (String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String) => R)(implicit tag: ClassTag[R]): Unit = {
+      register {
+        case List(p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, p14, p15, p16, p17, p18, p19, p20) =>
+          f(p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, p14, p15, p16, p17, p18, p19, p20)
+      }
+    }
+
+    def apply[R](f: (String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String) => R)(implicit tag: ClassTag[R]): Unit = {
+      register {
+        case List(p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, p14, p15, p16, p17, p18, p19, p20, p21) =>
+          f(p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, p14, p15, p16, p17, p18, p19, p20, p21)
+      }
+    }
+
+    def apply[R](f: (String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String) => R)(implicit tag: ClassTag[R]): Unit = {
+      register {
+        case List(p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, p14, p15, p16, p17, p18, p19, p20, p21, p22) =>
+          f(p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, p14, p15, p16, p17, p18, p19, p20, p21, p22)
+      }
+    }
+
+    private def register[R](pf: PartialFunction[List[String], R])(implicit tag: ClassTag[R]): Unit = {
+      registry.parameterTypes += ScalaParameterTypeDetails[R](name, regex, pf, tag)
     }
 
   }

--- a/scala/sources/src/main/scala/io/cucumber/scala/ScalaDsl.scala
+++ b/scala/sources/src/main/scala/io/cucumber/scala/ScalaDsl.scala
@@ -2,7 +2,7 @@ package io.cucumber.scala
 
 import java.lang.reflect.{ParameterizedType, Type}
 
-import io.cucumber.scala.Aliases.{DocStringDefinitionBody, HookBody}
+import io.cucumber.scala.Aliases.{DefaultDataTableCellTransformerBody, DefaultDataTableEntryTransformerBody, DefaultParameterTransformerBody, DocStringDefinitionBody, HookBody}
 
 import scala.reflect.ClassTag
 
@@ -22,7 +22,7 @@ private[scala] trait BaseScalaDsl {
 /**
  * Base trait for a scala step definition implementation.
  */
-trait ScalaDsl extends BaseScalaDsl with StepDsl with HookDsl with DataTableTypeDsl with DocStringTypeDsl with ParameterTypeDsl {
+trait ScalaDsl extends BaseScalaDsl with StepDsl with HookDsl with DataTableTypeDsl with DocStringTypeDsl with ParameterTypeDsl with DefaultTransformerDsl {
 
 }
 
@@ -300,6 +300,38 @@ private[scala] trait ParameterTypeDsl extends BaseScalaDsl {
       registry.parameterTypes += ScalaParameterTypeDetails[R](name, regex, pf, tag)
     }
 
+  }
+
+}
+
+private[scala] trait DefaultTransformerDsl extends BaseScalaDsl {
+
+  def DefaultParameterTransformer(body: DefaultParameterTransformerBody): Unit = {
+    registry.defaultParameterTransformers += ScalaDefaultParameterTransformerDetails(body)
+  }
+
+  def DefaultDataTableCellTransformer(body: DefaultDataTableCellTransformerBody): Unit = {
+    DefaultDataTableCellTransformer(NO_REPLACEMENT)(body)
+  }
+
+  def DefaultDataTableCellTransformer(replaceWithEmptyString: String)(body: DefaultDataTableCellTransformerBody): Unit = {
+    DefaultDataTableCellTransformer(Seq(replaceWithEmptyString))(body)
+  }
+
+  private def DefaultDataTableCellTransformer(replaceWithEmptyString: Seq[String])(body: DefaultDataTableCellTransformerBody): Unit = {
+    registry.defaultDataTableCellTransformers += ScalaDefaultDataTableCellTransformerDetails(replaceWithEmptyString, body)
+  }
+
+  def DefaultDataTableEntryTransformer(body: DefaultDataTableEntryTransformerBody): Unit = {
+    DefaultDataTableEntryTransformer(NO_REPLACEMENT)(body)
+  }
+
+  def DefaultDataTableEntryTransformer(replaceWithEmptyString: String)(body: DefaultDataTableEntryTransformerBody): Unit = {
+    DefaultDataTableEntryTransformer(Seq(replaceWithEmptyString))(body)
+  }
+
+  private def DefaultDataTableEntryTransformer(replaceWithEmptyString: Seq[String])(body: DefaultDataTableEntryTransformerBody): Unit = {
+    registry.defaultDataTableEntryTransformers += ScalaDefaultDataTableEntryTransformerDetails(replaceWithEmptyString, body)
   }
 
 }

--- a/scala/sources/src/main/scala/io/cucumber/scala/ScalaDslRegistry.scala
+++ b/scala/sources/src/main/scala/io/cucumber/scala/ScalaDslRegistry.scala
@@ -18,5 +18,7 @@ class ScalaDslRegistry {
 
   val dataTableTypes = new ArrayBuffer[ScalaDataTableTypeDetails[_]]
 
+  val parameterTypes = new ArrayBuffer[ScalaParameterTypeDetails[_]]
+
 }
 

--- a/scala/sources/src/main/scala/io/cucumber/scala/ScalaDslRegistry.scala
+++ b/scala/sources/src/main/scala/io/cucumber/scala/ScalaDslRegistry.scala
@@ -14,5 +14,9 @@ class ScalaDslRegistry {
 
   val afterStepHooks = new ArrayBuffer[ScalaHookDetails]
 
+  val docStringTypes = new ArrayBuffer[ScalaDocStringTypeDetails[_]]
+
+  val dataTableTypes = new ArrayBuffer[ScalaDataTableTypeDetails[_]]
+
 }
 

--- a/scala/sources/src/main/scala/io/cucumber/scala/ScalaDslRegistry.scala
+++ b/scala/sources/src/main/scala/io/cucumber/scala/ScalaDslRegistry.scala
@@ -20,5 +20,11 @@ class ScalaDslRegistry {
 
   val parameterTypes = new ArrayBuffer[ScalaParameterTypeDetails[_]]
 
+  val defaultParameterTransformers = new ArrayBuffer[ScalaDefaultParameterTransformerDetails]
+
+  val defaultDataTableCellTransformers = new ArrayBuffer[ScalaDefaultDataTableCellTransformerDetails]
+
+  val defaultDataTableEntryTransformers = new ArrayBuffer[ScalaDefaultDataTableEntryTransformerDetails]
+
 }
 

--- a/scala/sources/src/main/scala/io/cucumber/scala/ScalaParameterTypeDefinition.scala
+++ b/scala/sources/src/main/scala/io/cucumber/scala/ScalaParameterTypeDefinition.scala
@@ -1,0 +1,40 @@
+package io.cucumber.scala
+
+import io.cucumber.core.backend.{ParameterTypeDefinition, ScenarioScoped}
+import io.cucumber.cucumberexpressions.{CaptureGroupTransformer, ParameterType}
+
+import scala.collection.JavaConverters._
+
+trait ScalaParameterTypeDefinition[R] extends ParameterTypeDefinition with AbstractGlueDefinition {
+
+  val details: ScalaParameterTypeDetails[R]
+
+  override val location: StackTraceElement = new Exception().getStackTrace()(3)
+
+  private val transformer: CaptureGroupTransformer[R] = new CaptureGroupTransformer[R] {
+    override def transform(parameterContent: Array[String]): R = {
+      details.body.apply(parameterContent.toList)
+    }
+  }
+
+  override val parameterType: ParameterType[R] = new ParameterType[R](details.name, Seq(details.regex).asJava, details.tag.runtimeClass.asInstanceOf[Class[R]], transformer)
+
+}
+
+object ScalaParameterTypeDefinition {
+
+  def apply[R](stepDetails: ScalaParameterTypeDetails[R], scenarioScoped: Boolean): ScalaParameterTypeDefinition[R] = {
+    if (scenarioScoped) {
+      new ScalaScenarioScopedParameterTypeDefinition(stepDetails)
+    } else {
+      new ScalaGlobalParameterTypeDefinition(stepDetails)
+    }
+  }
+
+}
+
+class ScalaScenarioScopedParameterTypeDefinition[R](override val details: ScalaParameterTypeDetails[R]) extends ScalaParameterTypeDefinition[R] with ScenarioScoped {
+}
+
+class ScalaGlobalParameterTypeDefinition[R](override val details: ScalaParameterTypeDetails[R]) extends ScalaParameterTypeDefinition[R] {
+}

--- a/scala/sources/src/main/scala/io/cucumber/scala/ScalaParameterTypeDetails.scala
+++ b/scala/sources/src/main/scala/io/cucumber/scala/ScalaParameterTypeDetails.scala
@@ -1,0 +1,5 @@
+package io.cucumber.scala
+
+import scala.reflect.ClassTag
+
+case class ScalaParameterTypeDetails[R](name: String, regex: String, body: List[String] => R, tag: ClassTag[R])

--- a/scala/sources/src/test/resources/tests/datatables/Datatables.feature
+++ b/scala/sources/src/test/resources/tests/datatables/Datatables.feature
@@ -1,0 +1,99 @@
+Feature: As Cucumber Scala, I want to parse properly Datatables and use types and transformers
+
+  Scenario: Using a DataTableType for Entry - JList
+    Given the following authors as entries
+      | name   | surname | famousBook      |
+      | Alan   | Alou    | The Lion King   |
+      | Robert | Bob     | Le Petit Prince |
+    When I concat their names
+    Then I get "Alan,Robert"
+
+  Scenario: Using a DataTableType for Entry with empty values - JList
+    Given the following authors as entries with empty
+      | name    | surname | famousBook      |
+      | Alan    | Alou    | The Lion King   |
+      | [empty] | Bob     | Le Petit Prince |
+    When I concat their names
+    Then I get "Alan,"
+
+  Scenario: Using a DataTableType for Entry with empty values - DataTable
+    Given the following authors as entries with empty, as table
+      | name    | surname | famousBook      |
+      | Alan    | Alou    | The Lion King   |
+      | [empty] | Bob     | Le Petit Prince |
+    When I concat their names
+    Then I get "Alan,"
+
+  Scenario: Using a DataTableType for Row - Jlist
+    Given the following authors as rows
+      | Alan   | Alou | The Lion King   |
+      | Robert | Bob  | Le Petit Prince |
+    When I concat their names
+    Then I get "Alan,Robert"
+
+  Scenario: Using a DataTableType for Row, with empty values - Jlist
+    Given the following authors as rows with empty
+      | Alan    | Alou | The Lion King   |
+      | [empty] | Bob  | Le Petit Prince |
+    When I concat their names
+    Then I get "Alan,"
+
+  Scenario: Using a DataTableType for Row, with empty values - DataTable
+    Given the following authors as rows with empty, as table
+      | Alan    | Alou | The Lion King   |
+      | [empty] | Bob  | Le Petit Prince |
+    When I concat their names
+    Then I get "Alan,"
+
+  Scenario: Using a DataTableType for Cell - Jlist[Jlist]
+    Given the following authors as cells
+      | Alan   | Alou | The Lion King   |
+      | Robert | Bob  | Le Petit Prince |
+    When I concat their names
+    Then I get "Alan,Robert"
+
+  Scenario: Using a DataTableType for Cell, with empty values - Jlist[Jlist]
+    Given the following authors as cells with empty
+      | Alan    | Alou | The Lion King   |
+      | [empty] | Bob  | Le Petit Prince |
+    When I concat their names
+    Then I get "Alan,"
+
+  Scenario: Using a DataTableType for Cell, with empty values - JList[JMap]
+    Given the following authors as cells with empty, as map
+      | name    | surname | famousBook      |
+      | Alan    | Alou    | The Lion King   |
+      | [empty] | Bob     | Le Petit Prince |
+    When I concat their names
+    Then I get "Alan,"
+
+  Scenario: Using a DataTableType for Cell, with empty values - DataTable -> asMaps
+    Given the following authors as cells with empty, as table as map
+      | name    | surname | famousBook      |
+      | Alan    | Alou    | The Lion King   |
+      | [empty] | Bob     | Le Petit Prince |
+    When I concat their names
+    Then I get "Alan,"
+
+  Scenario: Using a DataTableType for Cell, with empty values - DataTable -> asLists
+    Given the following authors as cells with empty, as table as list
+      | Alan    | Alou    | The Lion King   |
+      | [empty] | Bob     | Le Petit Prince |
+    When I concat their names
+    Then I get "Alan,"
+
+  Scenario: Using a DataTableType for DataTable - DataTable
+    Given the following authors as table
+      | name   | surname | famousBook      |
+      | Alan   | Alou    | The Lion King   |
+      | Robert | Bob     | Le Petit Prince |
+    When I concat their names
+    Then I get "Alan,Robert"
+
+  Scenario: Using a DataTableType for DataTable with empty values - DataTable
+    Given the following authors as table with empty
+      | name    | surname | famousBook      |
+      | Alan    | Alou    | The Lion King   |
+      | [empty] | Bob     | Le Petit Prince |
+    When I concat their names
+    Then I get "Alan,"

--- a/scala/sources/src/test/resources/tests/docstring/Docstring.feature
+++ b/scala/sources/src/test/resources/tests/docstring/Docstring.feature
@@ -1,0 +1,17 @@
+Feature: As Cucumber Scala, I want to use DocStringType
+
+  Scenario: Using a DocStringType
+    Given the following json text
+      """json
+      {
+        "key": "value"
+      }
+      """
+    Then I have a json text
+
+  Scenario: Using another DocStringType
+    Given the following xml text
+      """xml
+      <xml></xml>
+      """
+    Then I have a xml text

--- a/scala/sources/src/test/resources/tests/parametertypes/ParameterTypes.feature
+++ b/scala/sources/src/test/resources/tests/parametertypes/ParameterTypes.feature
@@ -1,0 +1,10 @@
+Feature: As Cucumber Scala, I want to handle ParameterType definitions
+
+  Scenario: define parameter type with single argument
+    Given string builder parameter, defined by lambda
+
+  Scenario: define parameter type with two arguments
+    Given balloon coordinates 123,456, defined by lambda
+
+  Scenario: define parameter type with three arguments
+    Given kebab made from mushroom, meat and veg, defined by lambda

--- a/scala/sources/src/test/resources/tests/parametertypes/ParameterTypes.feature
+++ b/scala/sources/src/test/resources/tests/parametertypes/ParameterTypes.feature
@@ -8,3 +8,28 @@ Feature: As Cucumber Scala, I want to handle ParameterType definitions
 
   Scenario: define parameter type with three arguments
     Given kebab made from mushroom, meat and veg, defined by lambda
+
+  Scenario: define default parameter transformer
+    Given kebab made from anonymous meat, defined by lambda
+
+  Scenario: define default data table cell transformer - DataTable
+    Given default data table cells, defined by lambda
+      | Kebab   |
+      | [empty] |
+
+  Scenario: define default data table cell transformer - JList[Jlist]
+    Given default data table cells, defined by lambda, as rows
+      | Kebab   |
+      | [empty] |
+
+  Scenario: define default data table entry transformer - DataTable
+    Given default data table entries, defined by lambda
+      | dinner  |
+      | Kebab   |
+      | [empty] |
+
+  Scenario: define default data table entry transformer - JList
+    Given default data table entries, defined by lambda, as rows
+      | dinner  |
+      | Kebab   |
+      | [empty] |

--- a/scala/sources/src/test/scala/io/cucumber/scala/ScalaDslTest.scala
+++ b/scala/sources/src/test/scala/io/cucumber/scala/ScalaDslTest.scala
@@ -4,7 +4,7 @@ import java.util.concurrent.atomic.AtomicBoolean
 
 import io.cucumber.core.backend._
 import io.cucumber.datatable.DataTable
-import io.cucumber.scala.ScalaDslTest.{Author, Cell, GroupOfAuthor}
+import io.cucumber.scala.ScalaDslTest.{Author, Cell, GroupOfAuthor, Point}
 import org.junit.Assert.{assertEquals, assertTrue}
 import org.junit.{Before, Test}
 import org.mockito.Mockito.mock
@@ -31,6 +31,8 @@ object ScalaDslTest {
     Seq("Alan", "Alou", "The Lion King"),
     Seq("Robert", "[empty]", "Le Petit Prince")
   )
+
+  private case class Point(x: Int, y: Int)
 
 }
 
@@ -289,7 +291,7 @@ class ScalaDslTest {
 
     val glue = new Glue()
 
-    assertClassStepDefinition(glue.registry.stepDefinitions.head, "Something", "ScalaDslTest.scala:286", Array(), invoked)
+    assertClassStepDefinition(glue.registry.stepDefinitions.head, "Something", "ScalaDslTest.scala:288", Array(), invoked)
   }
 
   @Test
@@ -305,7 +307,7 @@ class ScalaDslTest {
 
     val glue = new Glue()
 
-    assertClassStepDefinition(glue.registry.stepDefinitions.head, "Something", "ScalaDslTest.scala:301", Array(), invoked)
+    assertClassStepDefinition(glue.registry.stepDefinitions.head, "Something", "ScalaDslTest.scala:303", Array(), invoked)
   }
 
   @Test
@@ -323,7 +325,7 @@ class ScalaDslTest {
 
     val glue = new Glue()
 
-    assertClassStepDefinition(glue.registry.stepDefinitions.head, """Oh boy, (\d+) (\s+) cukes""", "ScalaDslTest.scala:318", Array(new java.lang.Integer(5), "green"), thenumber == 5 && thecolour == "green")
+    assertClassStepDefinition(glue.registry.stepDefinitions.head, """Oh boy, (\d+) (\s+) cukes""", "ScalaDslTest.scala:320", Array(new java.lang.Integer(5), "green"), thenumber == 5 && thecolour == "green")
   }
 
   @Test
@@ -338,7 +340,7 @@ class ScalaDslTest {
 
     val glue = new GlueWithException()
 
-    assertClassStepDefinitionThrow(glue.registry.stepDefinitions.head, "io.cucumber.scala.ScalaDslTest$GlueWithException", "ScalaDslTest.scala", 335, Array())
+    assertClassStepDefinitionThrow(glue.registry.stepDefinitions.head, "io.cucumber.scala.ScalaDslTest$GlueWithException", "ScalaDslTest.scala", 337, Array())
   }
 
   @Test
@@ -505,6 +507,48 @@ class ScalaDslTest {
       Author("Robert", "", "Le Petit Prince")
     ))
     assertClassDataTableType(glue.registry.dataTableTypes.head, Seq("[empty]"), ScalaDslTest.DATATABLE_WITH_EMPTY, expected)
+  }
+
+  @Test
+  def testClassParameterType1(): Unit = {
+
+    class Glue extends ScalaDsl with EN {
+      ParameterType("string-builder", ".*") { str =>
+        new StringBuilder(str)
+      }
+    }
+
+    val glue = new Glue()
+
+    assertClassParameterType(glue.registry.parameterTypes.head, "string-builder", Seq(".*"), classOf[StringBuilder])
+  }
+
+  @Test
+  def testClassParameterType2(): Unit = {
+
+    class Glue extends ScalaDsl with EN {
+      ParameterType("coordinates", "(.+),(.+)") { (x, y) =>
+        Point(x.toInt, y.toInt)
+      }
+    }
+
+    val glue = new Glue()
+
+    assertClassParameterType(glue.registry.parameterTypes.head, "coordinates", Seq("(.+),(.+)"), classOf[Point])
+  }
+
+  @Test
+  def testClassParameterType3(): Unit = {
+
+    class Glue extends ScalaDsl with EN {
+      ParameterType("ingredients", "(.+), (.+) and (.+)") { (x, y, z) =>
+        s"$x-$y-$z"
+      }
+    }
+
+    val glue = new Glue()
+
+    assertClassParameterType(glue.registry.parameterTypes.head, "ingredients", Seq("(.+), (.+) and (.+)"), classOf[String])
   }
 
   // -------------------- Test on object --------------------
@@ -715,7 +759,7 @@ class ScalaDslTest {
       //@formatter:on
     }
 
-    assertObjectStepDefinition(Glue.registry.stepDefinitions.head, "Something", "ScalaDslTest.scala:714", Array(), invoked)
+    assertObjectStepDefinition(Glue.registry.stepDefinitions.head, "Something", "ScalaDslTest.scala:758", Array(), invoked)
   }
 
   @Test
@@ -729,7 +773,7 @@ class ScalaDslTest {
       }
     }
 
-    assertObjectStepDefinition(Glue.registry.stepDefinitions.head, "Something", "ScalaDslTest.scala:727", Array(), invoked)
+    assertObjectStepDefinition(Glue.registry.stepDefinitions.head, "Something", "ScalaDslTest.scala:771", Array(), invoked)
   }
 
   @Test
@@ -745,7 +789,7 @@ class ScalaDslTest {
       }
     }
 
-    assertObjectStepDefinition(Glue.registry.stepDefinitions.head, """Oh boy, (\d+) (\s+) cukes""", "ScalaDslTest.scala:742", Array(new java.lang.Integer(5), "green"), thenumber == 5 && thecolour == "green")
+    assertObjectStepDefinition(Glue.registry.stepDefinitions.head, """Oh boy, (\d+) (\s+) cukes""", "ScalaDslTest.scala:786", Array(new java.lang.Integer(5), "green"), thenumber == 5 && thecolour == "green")
   }
 
   @Test
@@ -758,7 +802,7 @@ class ScalaDslTest {
       }
     }
 
-    assertObjectStepDefinitionThrow(GlueWithException.registry.stepDefinitions.head, "io.cucumber.scala.ScalaDslTest$GlueWithException", "ScalaDslTest.scala", 757, Array())
+    assertObjectStepDefinitionThrow(GlueWithException.registry.stepDefinitions.head, "io.cucumber.scala.ScalaDslTest$GlueWithException", "ScalaDslTest.scala", 801, Array())
   }
 
   @Test
@@ -909,6 +953,42 @@ class ScalaDslTest {
     assertObjectDataTableType(Glue.registry.dataTableTypes.head, Seq("[empty]"), ScalaDslTest.DATATABLE_WITH_EMPTY, expected)
   }
 
+  @Test
+  def testObjectParameterType1(): Unit = {
+
+    object Glue extends ScalaDsl with EN {
+      ParameterType("string-builder", ".*") { str =>
+        new StringBuilder(str)
+      }
+    }
+
+    assertObjectParameterType(Glue.registry.parameterTypes.head, "string-builder", Seq(".*"), classOf[StringBuilder])
+  }
+
+  @Test
+  def testObjectParameterType2(): Unit = {
+
+    object Glue extends ScalaDsl with EN {
+      ParameterType("coordinates", "(.+),(.+)") { (x, y) =>
+        Point(x.toInt, y.toInt)
+      }
+    }
+
+    assertObjectParameterType(Glue.registry.parameterTypes.head, "coordinates", Seq("(.+),(.+)"), classOf[Point])
+  }
+
+  @Test
+  def testObjectParameterType3(): Unit = {
+
+    object Glue extends ScalaDsl with EN {
+      ParameterType("ingredients", "(.+), (.+) and (.+)") { (x, y, z) =>
+        s"$x-$y-$z"
+      }
+    }
+
+    assertObjectParameterType(Glue.registry.parameterTypes.head, "ingredients", Seq("(.+), (.+) and (.+)"), classOf[String])
+  }
+
 
   private def assertClassHook(hookDetails: ScalaHookDetails, tagExpression: String, order: Int): Unit = {
     assertHook(ScalaHookDefinition(hookDetails, true), tagExpression, order)
@@ -997,5 +1077,22 @@ class ScalaDslTest {
     assertEquals(expectedObj, obj)
   }
 
-}
+  private def assertClassParameterType(details: ScalaParameterTypeDetails[_], name: String, regexps: Seq[String], expectedType: Class[_]): Unit = {
+    assertParameterType(ScalaParameterTypeDefinition(details, true), name, regexps, expectedType)
+  }
 
+  private def assertObjectParameterType(details: ScalaParameterTypeDetails[_], name: String, regexps: Seq[String], expectedType: Class[_]): Unit = {
+    assertParameterType(ScalaParameterTypeDefinition(details, false), name, regexps, expectedType)
+  }
+
+  private def assertParameterType(parameterTypeDef: ParameterTypeDefinition, name: String, regexps: Seq[String], expectedType: Class[_]): Unit = {
+    val parameterType = parameterTypeDef.parameterType()
+
+    assertEquals(name, parameterType.getName)
+    assertEquals(regexps, parameterType.getRegexps.asScala)
+    assertEquals(expectedType, parameterType.getType)
+
+    // Cannot assert more because transform method is private
+  }
+
+}

--- a/scala/sources/src/test/scala/io/cucumber/scala/ScalaDslTest.scala
+++ b/scala/sources/src/test/scala/io/cucumber/scala/ScalaDslTest.scala
@@ -551,6 +551,78 @@ class ScalaDslTest {
     assertClassParameterType(glue.registry.parameterTypes.head, "ingredients", Seq("(.+), (.+) and (.+)"), classOf[String])
   }
 
+  @Test
+  def testClassDefaultParameterTransformer(): Unit = {
+
+    class Glue extends ScalaDsl with EN {
+      DefaultParameterTransformer { (fromValue: String, toValueType: java.lang.reflect.Type) =>
+        new StringBuilder().append(fromValue).append("-").append(toValueType)
+      }
+    }
+
+    val glue = new Glue()
+
+    assertClassDefaultParameterTransformer(glue.registry.defaultParameterTransformers.head, "meat", classOf[StringBuilder], "meat-class scala.collection.mutable.StringBuilder")
+  }
+
+
+  @Test
+  def testClassDefaultDataTableCellTransformer(): Unit = {
+
+    class Glue extends ScalaDsl with EN {
+      DefaultDataTableCellTransformer { (fromValue: String, toValueType: java.lang.reflect.Type) =>
+        new StringBuilder().append(fromValue).append("-").append(toValueType)
+      }
+    }
+
+    val glue = new Glue()
+
+    assertObjectDefaultDataTableCellTransformer(glue.registry.defaultDataTableCellTransformers.head, "meat", classOf[StringBuilder], "meat-class scala.collection.mutable.StringBuilder")
+  }
+
+  @Test
+  def testClassDefaultDataTableCellTransformerWithEmpty(): Unit = {
+
+    class Glue extends ScalaDsl with EN {
+      DefaultDataTableCellTransformer("[empty]") { (fromValue: String, toValueType: java.lang.reflect.Type) =>
+        new StringBuilder().append(fromValue).append("-").append(toValueType)
+      }
+    }
+
+    val glue = new Glue()
+
+    assertObjectDefaultDataTableCellTransformer(glue.registry.defaultDataTableCellTransformers.head, "meat", classOf[StringBuilder], "meat-class scala.collection.mutable.StringBuilder")
+    assertObjectDefaultDataTableCellTransformer(glue.registry.defaultDataTableCellTransformers.head, "[empty]", classOf[StringBuilder], "-class scala.collection.mutable.StringBuilder")
+  }
+
+  @Test
+  def testClassDefaultDataTableEntryTransformer(): Unit = {
+
+    class Glue extends ScalaDsl with EN {
+      DefaultDataTableEntryTransformer { (fromValue: Map[String, String], toValueType: java.lang.reflect.Type) =>
+        new StringBuilder().append(fromValue).append("-").append(toValueType)
+      }
+    }
+
+    val glue = new Glue()
+
+    assertObjectDefaultDataTableEntryTransformer(glue.registry.defaultDataTableEntryTransformers.head, Map("a" -> "b", "c" -> "d"), classOf[StringBuilder], "Map(a -> b, c -> d)-class scala.collection.mutable.StringBuilder")
+  }
+
+  @Test
+  def testClassDefaultDataTableEntryTransformerWithEmpty(): Unit = {
+
+    class Glue extends ScalaDsl with EN {
+      DefaultDataTableEntryTransformer("[empty]") { (fromValue: Map[String, String], toValueType: java.lang.reflect.Type) =>
+        new StringBuilder().append(fromValue).append("-").append(toValueType)
+      }
+    }
+
+    val glue = new Glue()
+
+    assertObjectDefaultDataTableEntryTransformer(glue.registry.defaultDataTableEntryTransformers.head, Map("a" -> "b", "c" -> "[empty]"), classOf[StringBuilder], "Map(a -> b, c -> )-class scala.collection.mutable.StringBuilder")
+  }
+
   // -------------------- Test on object --------------------
   // Note: for now there is no difference between the two in ScalaDsl but better safe than sorry
 
@@ -759,7 +831,7 @@ class ScalaDslTest {
       //@formatter:on
     }
 
-    assertObjectStepDefinition(Glue.registry.stepDefinitions.head, "Something", "ScalaDslTest.scala:758", Array(), invoked)
+    assertObjectStepDefinition(Glue.registry.stepDefinitions.head, "Something", "ScalaDslTest.scala:830", Array(), invoked)
   }
 
   @Test
@@ -773,7 +845,7 @@ class ScalaDslTest {
       }
     }
 
-    assertObjectStepDefinition(Glue.registry.stepDefinitions.head, "Something", "ScalaDslTest.scala:771", Array(), invoked)
+    assertObjectStepDefinition(Glue.registry.stepDefinitions.head, "Something", "ScalaDslTest.scala:843", Array(), invoked)
   }
 
   @Test
@@ -789,7 +861,7 @@ class ScalaDslTest {
       }
     }
 
-    assertObjectStepDefinition(Glue.registry.stepDefinitions.head, """Oh boy, (\d+) (\s+) cukes""", "ScalaDslTest.scala:786", Array(new java.lang.Integer(5), "green"), thenumber == 5 && thecolour == "green")
+    assertObjectStepDefinition(Glue.registry.stepDefinitions.head, """Oh boy, (\d+) (\s+) cukes""", "ScalaDslTest.scala:858", Array(new java.lang.Integer(5), "green"), thenumber == 5 && thecolour == "green")
   }
 
   @Test
@@ -802,7 +874,7 @@ class ScalaDslTest {
       }
     }
 
-    assertObjectStepDefinitionThrow(GlueWithException.registry.stepDefinitions.head, "io.cucumber.scala.ScalaDslTest$GlueWithException", "ScalaDslTest.scala", 801, Array())
+    assertObjectStepDefinitionThrow(GlueWithException.registry.stepDefinitions.head, "io.cucumber.scala.ScalaDslTest$GlueWithException", "ScalaDslTest.scala", 873, Array())
   }
 
   @Test
@@ -989,6 +1061,67 @@ class ScalaDslTest {
     assertObjectParameterType(Glue.registry.parameterTypes.head, "ingredients", Seq("(.+), (.+) and (.+)"), classOf[String])
   }
 
+  @Test
+  def testObjectDefaultParameterTransformer(): Unit = {
+
+    object Glue extends ScalaDsl with EN {
+      DefaultParameterTransformer { (fromValue: String, toValueType: java.lang.reflect.Type) =>
+        new StringBuilder().append(fromValue).append("-").append(toValueType)
+      }
+    }
+
+    assertObjectDefaultParameterTransformer(Glue.registry.defaultParameterTransformers.head, "meat", classOf[StringBuilder], "meat-class scala.collection.mutable.StringBuilder")
+  }
+
+  @Test
+  def testObjectDefaultDataTableCellTransformer(): Unit = {
+
+    object Glue extends ScalaDsl with EN {
+      DefaultDataTableCellTransformer { (fromValue: String, toValueType: java.lang.reflect.Type) =>
+        new StringBuilder().append(fromValue).append("-").append(toValueType)
+      }
+    }
+
+    assertObjectDefaultDataTableCellTransformer(Glue.registry.defaultDataTableCellTransformers.head, "meat", classOf[StringBuilder], "meat-class scala.collection.mutable.StringBuilder")
+  }
+
+  @Test
+  def testObjectDefaultDataTableCellTransformerWithEmpty(): Unit = {
+
+    object Glue extends ScalaDsl with EN {
+      DefaultDataTableCellTransformer("[empty]") { (fromValue: String, toValueType: java.lang.reflect.Type) =>
+        new StringBuilder().append(fromValue).append("-").append(toValueType)
+      }
+    }
+
+    assertObjectDefaultDataTableCellTransformer(Glue.registry.defaultDataTableCellTransformers.head, "meat", classOf[StringBuilder], "meat-class scala.collection.mutable.StringBuilder")
+    assertObjectDefaultDataTableCellTransformer(Glue.registry.defaultDataTableCellTransformers.head, "[empty]", classOf[StringBuilder], "-class scala.collection.mutable.StringBuilder")
+  }
+
+  @Test
+  def testObjectDefaultDataTableEntryTransformer(): Unit = {
+
+    object Glue extends ScalaDsl with EN {
+      DefaultDataTableEntryTransformer { (fromValue: Map[String, String], toValueType: java.lang.reflect.Type) =>
+        new StringBuilder().append(fromValue).append("-").append(toValueType)
+      }
+    }
+
+    assertObjectDefaultDataTableEntryTransformer(Glue.registry.defaultDataTableEntryTransformers.head, Map("a" -> "b", "c" -> "d"), classOf[StringBuilder], "Map(a -> b, c -> d)-class scala.collection.mutable.StringBuilder")
+  }
+
+  @Test
+  def testObjectDefaultDataTableEntryTransformerWithEmpty(): Unit = {
+
+    object Glue extends ScalaDsl with EN {
+      DefaultDataTableEntryTransformer("[empty]") { (fromValue: Map[String, String], toValueType: java.lang.reflect.Type) =>
+        new StringBuilder().append(fromValue).append("-").append(toValueType)
+      }
+    }
+
+    assertObjectDefaultDataTableEntryTransformer(Glue.registry.defaultDataTableEntryTransformers.head, Map("a" -> "b", "c" -> "[empty]"), classOf[StringBuilder], "Map(a -> b, c -> )-class scala.collection.mutable.StringBuilder")
+  }
+
 
   private def assertClassHook(hookDetails: ScalaHookDetails, tagExpression: String, order: Int): Unit = {
     assertHook(ScalaHookDefinition(hookDetails, true), tagExpression, order)
@@ -1093,6 +1226,45 @@ class ScalaDslTest {
     assertEquals(expectedType, parameterType.getType)
 
     // Cannot assert more because transform method is private
+  }
+
+  private def assertClassDefaultParameterTransformer(details: ScalaDefaultParameterTransformerDetails, input: String, toType: java.lang.reflect.Type, expectedOutput: AnyRef): Unit = {
+    assertDefaultParameterTransformer(ScalaDefaultParameterTransformerDefinition(details, true), input, toType, expectedOutput)
+  }
+
+  private def assertObjectDefaultParameterTransformer(details: ScalaDefaultParameterTransformerDetails, input: String, toType: java.lang.reflect.Type, expectedOutput: AnyRef): Unit = {
+    assertDefaultParameterTransformer(ScalaDefaultParameterTransformerDefinition(details, false), input, toType, expectedOutput)
+  }
+
+  private def assertDefaultParameterTransformer(typeDef: DefaultParameterTransformerDefinition, input: String, toType: java.lang.reflect.Type, expectedOutput: AnyRef): Unit = {
+    assertEquals(toType, typeDef.parameterByTypeTransformer().transform(input, toType).getClass)
+    assertEquals(expectedOutput.toString, typeDef.parameterByTypeTransformer().transform(input, toType).toString)
+  }
+
+  private def assertClassDefaultDataTableCellTransformer(details: ScalaDefaultDataTableCellTransformerDetails, input: String, toType: java.lang.reflect.Type, expectedOutput: AnyRef): Unit = {
+    assertDefaultDataTableCellTransformer(ScalaDefaultDataTableCellTransformerDefinition(details, true), input, toType, expectedOutput)
+  }
+
+  private def assertObjectDefaultDataTableCellTransformer(details: ScalaDefaultDataTableCellTransformerDetails, input: String, toType: java.lang.reflect.Type, expectedOutput: AnyRef): Unit = {
+    assertDefaultDataTableCellTransformer(ScalaDefaultDataTableCellTransformerDefinition(details, false), input, toType, expectedOutput)
+  }
+
+  private def assertDefaultDataTableCellTransformer(typeDef: DefaultDataTableCellTransformerDefinition, input: String, toType: java.lang.reflect.Type, expectedOutput: AnyRef): Unit = {
+    assertEquals(toType, typeDef.tableCellByTypeTransformer().transform(input, toType).getClass)
+    assertEquals(expectedOutput.toString, typeDef.tableCellByTypeTransformer().transform(input, toType).toString)
+  }
+
+  private def assertClassDefaultDataTableEntryTransformer(details: ScalaDefaultDataTableEntryTransformerDetails, input: Map[String, String], toType: java.lang.reflect.Type, expectedOutput: AnyRef): Unit = {
+    assertDefaultDataTableEntryTransformer(ScalaDefaultDataTableEntryTransformerDefinition(details, true), input, toType, expectedOutput)
+  }
+
+  private def assertObjectDefaultDataTableEntryTransformer(details: ScalaDefaultDataTableEntryTransformerDetails, input: Map[String, String], toType: java.lang.reflect.Type, expectedOutput: AnyRef): Unit = {
+    assertDefaultDataTableEntryTransformer(ScalaDefaultDataTableEntryTransformerDefinition(details, false), input, toType, expectedOutput)
+  }
+
+  private def assertDefaultDataTableEntryTransformer(typeDef: DefaultDataTableEntryTransformerDefinition, input: Map[String, String], toType: java.lang.reflect.Type, expectedOutput: AnyRef): Unit = {
+    assertEquals(toType, typeDef.tableEntryByTypeTransformer().transform(input.asJava, toType, null).getClass)
+    assertEquals(expectedOutput.toString, typeDef.tableEntryByTypeTransformer().transform(input.asJava, toType, null).toString)
   }
 
 }

--- a/scala/sources/src/test/scala/tests/datatables/DatatablesSteps.scala
+++ b/scala/sources/src/test/scala/tests/datatables/DatatablesSteps.scala
@@ -1,0 +1,179 @@
+package tests.datatables
+
+import io.cucumber.scala.{EN, ScalaDsl}
+import java.util.{List => JList, Map => JMap}
+
+import io.cucumber.datatable.DataTable
+
+import scala.collection.JavaConverters._
+
+
+class DatatablesSteps extends ScalaDsl with EN {
+
+  case class GroupOfAuthor(authors: Seq[Author])
+
+  case class GroupOfAuthorWithEmpty(authors: Seq[Author])
+
+  case class Author(name: String, surname: String, famousBook: String)
+
+  case class AuthorWithEmpty(name: String, surname: String, famousBook: String) {
+    def toAuthor: Author = Author(name, surname, famousBook)
+  }
+
+  case class AuthorRow(name: String, surname: String, famousBook: String) {
+    def toAuthor: Author = Author(name, surname, famousBook)
+  }
+
+  case class AuthorRowWithEmpty(name: String, surname: String, famousBook: String) {
+    def toAuthor: Author = Author(name, surname, famousBook)
+  }
+
+  case class AuthorCell(cell: String)
+
+  case class AuthorCellWithEmpty(cell: String)
+
+  var _authors: Seq[Author] = _
+  var _names: String = _
+
+  DataTableType { entry: Map[String, String] =>
+    Author(entry("name"), entry("surname"), entry("famousBook"))
+  }
+
+  DataTableType("[empty]") { (entry: Map[String, String]) =>
+    AuthorWithEmpty(entry("name"), entry("surname"), entry("famousBook"))
+  }
+
+  DataTableType { row: Seq[String] =>
+    AuthorRow(row(0), row(1), row(2))
+  }
+
+  DataTableType("[empty]") {(row: Seq[String]) =>
+    AuthorRowWithEmpty(row(0), row(1), row(2))
+  }
+
+  DataTableType { cell: String =>
+    AuthorCell(cell)
+  }
+
+  DataTableType("[empty]") { (cell: String) =>
+    AuthorCellWithEmpty(cell)
+  }
+
+  DataTableType { table: DataTable =>
+    val authors = table.asMaps().asScala
+      .map(_.asScala)
+      .map(entry => Author(entry("name"), entry("surname"), entry("famousBook")))
+      .toSeq
+    GroupOfAuthor(authors)
+  }
+
+  DataTableType("[empty]") {(table: DataTable) =>
+    val authors = table.asMaps().asScala
+      .map(_.asScala)
+      .map(entry => Author(entry("name"), entry("surname"), entry("famousBook")))
+      .toSeq
+    GroupOfAuthorWithEmpty(authors)
+  }
+
+  Given("the following authors as entries") { (authors: JList[Author]) =>
+    _authors = authors
+      .asScala
+      .toSeq
+  }
+
+  Given("the following authors as entries with empty") { (authors: JList[AuthorWithEmpty]) =>
+    _authors = authors
+      .asScala
+      .toSeq
+      .map(_.toAuthor)
+  }
+
+  Given("the following authors as entries with empty, as table") { (authors: DataTable) =>
+    _authors = authors
+      .asList[AuthorWithEmpty](classOf[AuthorWithEmpty])
+      .asScala
+      .toSeq
+      .map(_.toAuthor)
+  }
+
+  Given("the following authors as rows") { (authors: JList[AuthorRow]) =>
+    _authors = authors
+      .asScala
+      .toSeq
+      .map(_.toAuthor)
+  }
+
+  Given("the following authors as rows with empty") { (authors: JList[AuthorRowWithEmpty]) =>
+    _authors = authors
+      .asScala
+      .toSeq
+      .map(_.toAuthor)
+  }
+
+  Given("the following authors as rows with empty, as table") { (authors: DataTable) =>
+    _authors = authors
+      .asList[AuthorRowWithEmpty](classOf[AuthorRowWithEmpty])
+      .asScala
+      .toSeq
+      .map(_.toAuthor)
+  }
+
+  Given("the following authors as cells") { (authors: JList[JList[AuthorCell]]) =>
+    _authors = authors
+      .asScala
+      .map(_.asScala)
+      .toSeq
+      .map(line => Author(line(0).cell, line(1).cell, line(2).cell))
+  }
+
+  Given("the following authors as cells with empty") { (authors: JList[JList[AuthorCellWithEmpty]]) =>
+    _authors = authors
+      .asScala
+      .map(_.asScala)
+      .toSeq
+      .map(line => Author(line(0).cell, line(1).cell, line(2).cell))
+  }
+
+  Given("the following authors as cells with empty, as map") { (authors: JList[JMap[String, AuthorCellWithEmpty]]) =>
+    _authors = authors
+      .asScala
+      .toSeq
+      .map(_.asScala)
+      .map(line => Author(line("name").cell, line("surname").cell, line("famousBook").cell))
+  }
+
+  Given("the following authors as cells with empty, as table as map") { (authors: DataTable) =>
+    _authors = authors
+      .asMaps[String, AuthorCellWithEmpty](classOf[String], classOf[AuthorCellWithEmpty])
+      .asScala
+      .toSeq
+      .map(_.asScala)
+      .map(line => Author(line("name").cell, line("surname").cell, line("famousBook").cell))
+  }
+
+  Given("the following authors as cells with empty, as table as list") { (authors: DataTable) =>
+    _authors = authors
+      .asLists[AuthorCellWithEmpty](classOf[AuthorCellWithEmpty])
+      .asScala
+      .toSeq
+      .map(_.asScala)
+      .map(line => Author(line(0).cell, line(1).cell, line(2).cell))
+  }
+
+  Given("the following authors as table") { (authors: DataTable) =>
+    _authors = authors.convert[GroupOfAuthor](classOf[GroupOfAuthor], false).authors
+  }
+
+  Given("the following authors as table with empty") { (authors: DataTable) =>
+    _authors = authors.convert[GroupOfAuthorWithEmpty](classOf[GroupOfAuthorWithEmpty], false).authors
+  }
+
+  When("I concat their names") {
+    _names = _authors.map(_.name).mkString(",")
+  }
+
+  Then("""I get {string}""") { expected: String =>
+    assert(_names == expected)
+  }
+
+}

--- a/scala/sources/src/test/scala/tests/datatables/RunDatatablesTest.scala
+++ b/scala/sources/src/test/scala/tests/datatables/RunDatatablesTest.scala
@@ -1,0 +1,8 @@
+package tests.datatables
+
+import io.cucumber.junit.{Cucumber, CucumberOptions}
+import org.junit.runner.RunWith
+
+@RunWith(classOf[Cucumber])
+@CucumberOptions(strict = true)
+class RunDatatablesTest

--- a/scala/sources/src/test/scala/tests/docstring/DocStringSteps.scala
+++ b/scala/sources/src/test/scala/tests/docstring/DocStringSteps.scala
@@ -1,0 +1,38 @@
+package tests.docstring
+
+import io.cucumber.scala.{EN, ScalaDsl}
+
+
+class DocStringSteps extends ScalaDsl with EN {
+
+  case class JsonText(json: String)
+
+  case class XmlText(xml: String)
+
+  var _text: Any = _
+
+  DocStringType("json") { text =>
+    JsonText(text)
+  }
+
+  DocStringType("xml") { text =>
+    XmlText(text)
+  }
+
+  Given("the following json text") { json: JsonText =>
+    _text = json
+  }
+
+  Given("the following xml text") { xml: XmlText =>
+    _text = xml
+  }
+
+  Then("I have a json text") {
+    assert(_text.isInstanceOf[JsonText])
+  }
+
+  Then("I have a xml text") {
+    assert(_text.isInstanceOf[XmlText])
+  }
+
+}

--- a/scala/sources/src/test/scala/tests/docstring/RunDocStringTest.scala
+++ b/scala/sources/src/test/scala/tests/docstring/RunDocStringTest.scala
@@ -1,0 +1,8 @@
+package tests.docstring
+
+import io.cucumber.junit.{Cucumber, CucumberOptions}
+import org.junit.runner.RunWith
+
+@RunWith(classOf[Cucumber])
+@CucumberOptions(strict = true)
+class RunDocStringTest

--- a/scala/sources/src/test/scala/tests/parametertypes/ParameterTypesSteps.scala
+++ b/scala/sources/src/test/scala/tests/parametertypes/ParameterTypesSteps.scala
@@ -1,6 +1,11 @@
 package tests.parametertypes
 
+import java.util.{List => JavaList}
+
+import io.cucumber.datatable.DataTable
 import io.cucumber.scala.{EN, ScalaDsl}
+
+import scala.collection.JavaConverters._
 
 case class Point(x: Int, y: Int)
 
@@ -18,6 +23,18 @@ class ParameterTypesSteps extends ScalaDsl with EN {
     s"-$x-$y-$z-"
   }
 
+  DefaultParameterTransformer { (fromValue, toValueType) =>
+    new StringBuilder().append(fromValue).append('-').append(toValueType)
+  }
+
+  DefaultDataTableCellTransformer("[empty]") { (fromValue: String, toValueType) =>
+    new StringBuilder().append(fromValue).append("-").append(toValueType)
+  }
+
+  DefaultDataTableEntryTransformer("[empty]") { (fromValue: Map[String, String], toValueType) =>
+    new StringBuilder().append(fromValue).append("-").append(toValueType)
+  }
+
   Given("{string-builder} parameter, defined by lambda") { builder: StringBuilder =>
     assert(builder.toString() == "string builder")
   }
@@ -28,6 +45,34 @@ class ParameterTypesSteps extends ScalaDsl with EN {
 
   Given("kebab made from {ingredients}, defined by lambda") { (ingredients: String) =>
     assert(ingredients == "-mushroom-meat-veg-")
+  }
+
+  Given("kebab made from anonymous {}, defined by lambda") { (ingredients: StringBuilder) =>
+    assert(ingredients.toString() == "meat-class scala.collection.mutable.StringBuilder")
+  }
+
+  Given("default data table cells, defined by lambda") { (dataTable: DataTable) =>
+    val table = dataTable.asLists[StringBuilder](classOf[StringBuilder]).asScala.map(_.asScala)
+    assert(table(0)(0).toString() == "Kebab-class scala.collection.mutable.StringBuilder")
+    assert(table(1)(0).toString() == "-class scala.collection.mutable.StringBuilder")
+  }
+
+  Given("default data table cells, defined by lambda, as rows") { (cells: JavaList[JavaList[StringBuilder]]) =>
+    val table = cells.asScala.map(_.asScala)
+    assert(table(0)(0).toString() == "Kebab-class scala.collection.mutable.StringBuilder")
+    assert(table(1)(0).toString() == "-class scala.collection.mutable.StringBuilder")
+  }
+
+  Given("default data table entries, defined by lambda") { (dataTable: DataTable) =>
+    val table = dataTable.asList[StringBuilder](classOf[StringBuilder]).asScala
+    assert(table(0).toString() == "Map(dinner -> Kebab)-class scala.collection.mutable.StringBuilder")
+    assert(table(1).toString() == "Map(dinner -> )-class scala.collection.mutable.StringBuilder")
+  }
+
+  Given("default data table entries, defined by lambda, as rows") { (rows: JavaList[StringBuilder]) =>
+    val table = rows.asScala
+    assert(table(0).toString() == "Map(dinner -> Kebab)-class scala.collection.mutable.StringBuilder")
+    assert(table(1).toString() == "Map(dinner -> )-class scala.collection.mutable.StringBuilder")
   }
 
 }

--- a/scala/sources/src/test/scala/tests/parametertypes/ParameterTypesSteps.scala
+++ b/scala/sources/src/test/scala/tests/parametertypes/ParameterTypesSteps.scala
@@ -1,0 +1,33 @@
+package tests.parametertypes
+
+import io.cucumber.scala.{EN, ScalaDsl}
+
+case class Point(x: Int, y: Int)
+
+class ParameterTypesSteps extends ScalaDsl with EN {
+
+  ParameterType("string-builder", ".*") { str =>
+    new StringBuilder(str)
+  }
+
+  ParameterType("coordinates", "(.+),(.+)") { (x, y) =>
+    Point(x.toInt, y.toInt)
+  }
+
+  ParameterType("ingredients", "(.+), (.+) and (.+)") { (x, y, z) =>
+    s"-$x-$y-$z-"
+  }
+
+  Given("{string-builder} parameter, defined by lambda") { builder: StringBuilder =>
+    assert(builder.toString() == "string builder")
+  }
+
+  Given("balloon coordinates {coordinates}, defined by lambda") { (coordinates: Point) =>
+    assert(coordinates == Point(123, 456))
+  }
+
+  Given("kebab made from {ingredients}, defined by lambda") { (ingredients: String) =>
+    assert(ingredients == "-mushroom-meat-veg-")
+  }
+
+}

--- a/scala/sources/src/test/scala/tests/parametertypes/RunParameterTypesTest.scala
+++ b/scala/sources/src/test/scala/tests/parametertypes/RunParameterTypesTest.scala
@@ -1,0 +1,8 @@
+package tests.parametertypes
+
+import io.cucumber.junit.{Cucumber, CucumberOptions}
+import org.junit.runner.RunWith
+
+@RunWith(classOf[Cucumber])
+@CucumberOptions(strict = true)
+class RunParameterTypesTest


### PR DESCRIPTION
Aims to fix #32 

# Content

- Implement `DataTableType`, `DocStringType`, `ParameterType`, `DefaultParameterTransformer`, `DefaultDataTableCellTransformer` and `DefaultDataTableEntryTransformer`
- Add related tests
- Add related doc