### PR TITLE
Add recommended list of scalac flags for Scala 2.13

### DIFF
--- a/scala/pom.xml
+++ b/scala/pom.xml
@@ -46,15 +46,6 @@
                     <groupId>net.alchim31.maven</groupId>
                     <artifactId>scala-maven-plugin</artifactId>
                     <version>${scala-maven-plugin.version}</version>
-                    <configuration>
-                        <args>
-                            <arg>-feature</arg>
-                            <arg>-deprecation</arg>
-                        </args>
-                        <excludes>
-                            <exclude>**/*.java</exclude>
-                        </excludes>
-                    </configuration>
                     <executions>
                         <execution>
                             <id>regular-source-compilation</id>

--- a/scala/scala_2.11/pom.xml
+++ b/scala/scala_2.11/pom.xml
@@ -1,4 +1,5 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
@@ -81,6 +82,15 @@
             <plugin>
                 <groupId>net.alchim31.maven</groupId>
                 <artifactId>scala-maven-plugin</artifactId>
+                <configuration>
+                    <args>
+                        <arg>-deprecation</arg>
+                        <arg>-feature</arg>
+                    </args>
+                    <excludes>
+                        <exclude>**/*.java</exclude>
+                    </excludes>
+                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/scala/scala_2.12/pom.xml
+++ b/scala/scala_2.12/pom.xml
@@ -1,4 +1,5 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
@@ -56,9 +57,9 @@
         </resources>
         <testSourceDirectory>../sources/src/test/scala</testSourceDirectory>
         <testResources>
-          <testResource>
-            <directory>../sources/src/test/resources</directory>
-          </testResource>
+            <testResource>
+                <directory>../sources/src/test/resources</directory>
+            </testResource>
         </testResources>
         <plugins>
             <plugin>
@@ -72,6 +73,17 @@
             <plugin>
                 <groupId>net.alchim31.maven</groupId>
                 <artifactId>scala-maven-plugin</artifactId>
+                <configuration>
+                    <args>
+                        <!-- Emit warning and location for usages of deprecated APIs. -->
+                        <arg>-deprecation</arg>
+                        <!-- Emit warning and location for usages of features that should be imported explicitly. -->
+                        <arg>-feature</arg>
+                    </args>
+                    <excludes>
+                        <exclude>**/*.java</exclude>
+                    </excludes>
+                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/scala/scala_2.13/pom.xml
+++ b/scala/scala_2.13/pom.xml
@@ -1,4 +1,5 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
@@ -51,9 +52,9 @@
         </resources>
         <testSourceDirectory>../sources/src/test/scala</testSourceDirectory>
         <testResources>
-          <testResource>
-            <directory>../sources/src/test/resources</directory>
-          </testResource>
+            <testResource>
+                <directory>../sources/src/test/resources</directory>
+            </testResource>
         </testResources>
         <plugins>
             <plugin>
@@ -67,6 +68,91 @@
             <plugin>
                 <groupId>net.alchim31.maven</groupId>
                 <artifactId>scala-maven-plugin</artifactId>
+                <configuration>
+                    <!-- https://nathankleyn.com/2019/05/13/recommended-scalac-flags-for-2-13/ -->
+                    <args>
+                        <!-- Emit warning and location for usages of deprecated APIs. -->
+                        <arg>-deprecation</arg>
+                        <!-- Explain type errors in more detail. -->
+                        <arg>-explaintypes</arg>
+                        <!-- Emit warning and location for usages of features that should be imported explicitly. -->
+                        <arg>-feature</arg>
+                        <!-- Existential types (besides wildcard types) can be written and inferred -->
+                        <arg>-language:existentials</arg>
+                        <!-- Allow macro definition (besides implementation and application) -->
+                        <arg>-language:experimental.macros</arg>
+                        <!-- Allow higher-kinded types -->
+                        <arg>-language:higherKinds</arg>
+                        <!-- Allow definition of implicit functions called views -->
+                        <arg>-language:implicitConversions</arg>
+                        <!-- Enable additional warnings where generated code depends on assumptions. -->
+                        <arg>-unchecked</arg>
+                        <!-- Wrap field accessors to throw an exception on uninitialized access. -->
+                        <arg>-Xcheckinit</arg>
+                        <!-- Fail the compilation if there are any warnings. -->
+                        <arg>-Xfatal-warnings</arg>
+                        <!-- Warn if an argument list is modified to match the receiver. -->
+                        <arg>-Xlint:adapted-args</arg>
+                        <!-- Evaluation of a constant arithmetic expression results in an error. -->
+                        <arg>-Xlint:constant</arg>
+                        <!-- Selecting member of DelayedInit. -->
+                        <arg>-Xlint:delayedinit-select</arg>
+                        <!-- A Scaladoc comment appears to be detached from its element. -->
+                        <arg>-Xlint:doc-detached</arg>
+                        <!-- Warn about inaccessible types in method signatures. -->
+                        <arg>-Xlint:inaccessible</arg>
+                        <!-- Warn when a type argument is inferred to be `Any`. -->
+                        <arg>-Xlint:infer-any</arg>
+                        <!-- A string literal appears to be missing an interpolator id. -->
+                        <arg>-Xlint:missing-interpolator</arg>
+                        <!-- Warn when non-nullary `def f()' overrides nullary `def f'. -->
+                        <arg>-Xlint:nullary-override</arg>
+                        <!-- Warn when nullary methods return Unit. -->
+                        <arg>-Xlint:nullary-unit</arg>
+                        <!-- Option.apply used implicit view. -->
+                        <arg>-Xlint:option-implicit</arg>
+                        <!-- Class or object defined in package object. -->
+                        <arg>-Xlint:package-object-classes</arg>
+                        <!-- Parameterized overloaded implicit methods are not visible as view bounds. -->
+                        <arg>-Xlint:poly-implicit-overload</arg>
+                        <!-- A private field (or class parameter) shadows a superclass field. -->
+                        <arg>-Xlint:private-shadow</arg>
+                        <!-- Pattern sequence wildcard must align with sequence component. -->
+                        <arg>-Xlint:stars-align</arg>
+                        <!-- A local type parameter shadows a type already in scope. -->
+                        <arg>-Xlint:type-parameter-shadow</arg>
+                        <!-- Warn when dead code is identified. -->
+                        <arg>-Ywarn-dead-code</arg>
+                        <!-- Warn when more than one implicit parameter section is defined. -->
+                        <arg>-Ywarn-extra-implicit</arg>
+                        <!-- Warn when numerics are widened. -->
+                        <arg>-Ywarn-numeric-widen</arg>
+                        <!-- Warn if an implicit parameter is unused. -->
+                        <arg>-Ywarn-unused:implicits</arg>
+                        <!-- Warn if an import selector is not referenced. -->
+                        <arg>-Ywarn-unused:imports</arg>
+                        <!-- Warn if a local definition is unused. -->
+                        <arg>-Ywarn-unused:locals</arg>
+                        <!-- Warn if a value parameter is unused. -->
+                        <arg>-Ywarn-unused:params</arg>
+                        <!-- Warn if a variable bound in a pattern is unused. -->
+                        <arg>-Ywarn-unused:patvars</arg>
+                        <!-- Warn if a private member is unused. -->
+                        <arg>-Ywarn-unused:privates</arg>
+                        <!-- Warn when non-Unit expression results are unused. -->
+                        <arg>-Ywarn-value-discard</arg>
+                        <!-- Enable paralellisation — change to desired number! -->
+                        <arg>-Ybackend-parallelism</arg>
+                        <arg>8</arg>
+                        <!-- Enables caching of classloaders for compiler plugins -->
+                        <arg>-Ycache-plugin-class-loader:last-modified</arg>
+                        <!-- and macro definitions. This can lead to performance improvements. -->
+                        <arg>-Ycache-macro-class-loader:last-modified</arg>
+                    </args>
+                    <excludes>
+                        <exclude>**/*.java</exclude>
+                    </excludes>
+                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/scala/sources/src/main/scala/io/cucumber/scala/ScalaDefaultDataTableEntryTransformerDefinition.scala
+++ b/scala/sources/src/main/scala/io/cucumber/scala/ScalaDefaultDataTableEntryTransformerDefinition.scala
@@ -16,7 +16,7 @@ trait ScalaDefaultDataTableEntryTransformerDefinition extends DefaultDataTableEn
 
   override val location: StackTraceElement = new Exception().getStackTrace()(3)
 
-  override val tableEntryByTypeTransformer: TableEntryByTypeTransformer = (fromValue: JavaMap[String, String], toValueType: Type, tableCellByTypeTransformer: TableCellByTypeTransformer) => {
+  override val tableEntryByTypeTransformer: TableEntryByTypeTransformer = (fromValue: JavaMap[String, String], toValueType: Type, _: TableCellByTypeTransformer) => {
     replaceEmptyPatternsWithEmptyString(fromValue.asScala.toMap)
       .map(details.body.apply(_, toValueType))
       .get

--- a/scala/sources/src/main/scala/io/cucumber/scala/ScalaDsl.scala
+++ b/scala/sources/src/main/scala/io/cucumber/scala/ScalaDsl.scala
@@ -486,8 +486,6 @@ private[scala] trait StepDsl extends BaseScalaDsl {
 
   object Fun0 {
 
-    import scala.language.implicitConversions
-
     implicit def function0AsFun0(f: Function0[Any]): Fun0 = new Fun0(f)
 
   }

--- a/scala/sources/src/main/scala/io/cucumber/scala/ScalaStepDefinition.scala
+++ b/scala/sources/src/main/scala/io/cucumber/scala/ScalaStepDefinition.scala
@@ -26,7 +26,10 @@ trait ScalaStepDefinition extends StepDefinition with AbstractGlueDefinition {
   }
 
   override def execute(args: Array[AnyRef]): Unit = {
-    executeAsCucumber(stepDetails.body(args.toList))
+    executeAsCucumber {
+      stepDetails.body(args.toList)
+      ()
+    }
   }
 
   override def getPattern: String = stepDetails.pattern

--- a/scala/sources/src/test/scala/io/cucumber/scala/ScalaBackendTest.scala
+++ b/scala/sources/src/test/scala/io/cucumber/scala/ScalaBackendTest.scala
@@ -11,8 +11,10 @@ import org.junit.{Before, Test}
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito._
 
+import scala.annotation.nowarn
 import scala.jdk.CollectionConverters._
 
+@nowarn
 class ScalaBackendTest {
 
   private val fakeGlue: Glue = mock(classOf[Glue])

--- a/scala/sources/src/test/scala/io/cucumber/scala/ScalaDslDocStringTypeTest.scala
+++ b/scala/sources/src/test/scala/io/cucumber/scala/ScalaDslDocStringTypeTest.scala
@@ -3,7 +3,9 @@ package io.cucumber.scala
 import io.cucumber.core.backend._
 import org.junit.Test
 
+import scala.annotation.nowarn
 
+@nowarn
 class ScalaDslDocStringTypeTest {
 
   @Test

--- a/scala/sources/src/test/scala/io/cucumber/scala/ScalaDslHooksTest.scala
+++ b/scala/sources/src/test/scala/io/cucumber/scala/ScalaDslHooksTest.scala
@@ -7,6 +7,9 @@ import org.junit.Assert.{assertEquals, assertTrue}
 import org.junit.{Before, Test}
 import org.mockito.Mockito.mock
 
+import scala.annotation.nowarn
+
+@nowarn
 class ScalaDslHooksTest {
 
   private val fakeState = mock(classOf[TestCaseState])

--- a/scala/sources/src/test/scala/io/cucumber/scala/ScalaDslStepsTest.scala
+++ b/scala/sources/src/test/scala/io/cucumber/scala/ScalaDslStepsTest.scala
@@ -4,8 +4,10 @@ import io.cucumber.core.backend._
 import org.junit.Assert.{assertEquals, assertTrue}
 import org.junit.Test
 
+import scala.annotation.nowarn
 import scala.util.Try
 
+@nowarn
 class ScalaDslStepsTest {
 
   @Test
@@ -22,7 +24,7 @@ class ScalaDslStepsTest {
 
     val glue = new Glue()
 
-    assertClassStepDefinition(glue.registry.stepDefinitions.head, "Something", "ScalaDslStepsTest.scala:19", Array(), invoked)
+    assertClassStepDefinition(glue.registry.stepDefinitions.head, "Something", "ScalaDslStepsTest.scala:21", Array(), invoked)
   }
 
   @Test
@@ -38,7 +40,7 @@ class ScalaDslStepsTest {
 
     val glue = new Glue()
 
-    assertClassStepDefinition(glue.registry.stepDefinitions.head, "Something", "ScalaDslStepsTest.scala:34", Array(), invoked)
+    assertClassStepDefinition(glue.registry.stepDefinitions.head, "Something", "ScalaDslStepsTest.scala:36", Array(), invoked)
   }
 
   @Test
@@ -56,7 +58,7 @@ class ScalaDslStepsTest {
 
     val glue = new Glue()
 
-    assertClassStepDefinition(glue.registry.stepDefinitions.head, """Oh boy, (\d+) (\s+) cukes""", "ScalaDslStepsTest.scala:51", Array(new java.lang.Integer(5), "green"), thenumber == 5 && thecolour == "green")
+    assertClassStepDefinition(glue.registry.stepDefinitions.head, """Oh boy, (\d+) (\s+) cukes""", "ScalaDslStepsTest.scala:53", Array(new java.lang.Integer(5), "green"), thenumber == 5 && thecolour == "green")
   }
 
   @Test
@@ -71,7 +73,7 @@ class ScalaDslStepsTest {
 
     val glue = new GlueWithException()
 
-    assertClassStepDefinitionThrow(glue.registry.stepDefinitions.head, "io.cucumber.scala.ScalaDslStepsTest$GlueWithException", "ScalaDslStepsTest.scala", 68, Array())
+    assertClassStepDefinitionThrow(glue.registry.stepDefinitions.head, "io.cucumber.scala.ScalaDslStepsTest$GlueWithException", "ScalaDslStepsTest.scala", 70, Array())
   }
 
   // -------------------- Test on object --------------------
@@ -89,7 +91,7 @@ class ScalaDslStepsTest {
       //@formatter:on
     }
 
-    assertObjectStepDefinition(Glue.registry.stepDefinitions.head, "Something", "ScalaDslStepsTest.scala:88", Array(), invoked)
+    assertObjectStepDefinition(Glue.registry.stepDefinitions.head, "Something", "ScalaDslStepsTest.scala:90", Array(), invoked)
   }
 
   @Test
@@ -103,7 +105,7 @@ class ScalaDslStepsTest {
       }
     }
 
-    assertObjectStepDefinition(Glue.registry.stepDefinitions.head, "Something", "ScalaDslStepsTest.scala:101", Array(), invoked)
+    assertObjectStepDefinition(Glue.registry.stepDefinitions.head, "Something", "ScalaDslStepsTest.scala:103", Array(), invoked)
   }
 
   @Test
@@ -119,7 +121,7 @@ class ScalaDslStepsTest {
       }
     }
 
-    assertObjectStepDefinition(Glue.registry.stepDefinitions.head, """Oh boy, (\d+) (\s+) cukes""", "ScalaDslStepsTest.scala:116", Array(new java.lang.Integer(5), "green"), thenumber == 5 && thecolour == "green")
+    assertObjectStepDefinition(Glue.registry.stepDefinitions.head, """Oh boy, (\d+) (\s+) cukes""", "ScalaDslStepsTest.scala:118", Array(new java.lang.Integer(5), "green"), thenumber == 5 && thecolour == "green")
   }
 
   @Test
@@ -132,7 +134,7 @@ class ScalaDslStepsTest {
       }
     }
 
-    assertObjectStepDefinitionThrow(GlueWithException.registry.stepDefinitions.head, "io.cucumber.scala.ScalaDslStepsTest$GlueWithException", "ScalaDslStepsTest.scala", 131, Array())
+    assertObjectStepDefinitionThrow(GlueWithException.registry.stepDefinitions.head, "io.cucumber.scala.ScalaDslStepsTest$GlueWithException", "ScalaDslStepsTest.scala", 133, Array())
   }
 
   private def assertClassStepDefinition(stepDetails: ScalaStepDetails, pattern: String, location: String, args: Array[AnyRef], check: => Boolean): Unit = {

--- a/scala/sources/src/test/scala/tests/cukes/StepDefs.scala
+++ b/scala/sources/src/test/scala/tests/cukes/StepDefs.scala
@@ -7,11 +7,13 @@ import io.cucumber.scala.{EN, ScalaDsl}
 import org.junit.Assert.assertEquals
 import tests.cukes.model.{Cukes, Person, Snake}
 
+import scala.annotation.nowarn
 import scala.jdk.CollectionConverters._
 
 /**
  * Test step definitions to exercise Scala cucumber
  */
+@nowarn
 class CukesStepDefinitions extends ScalaDsl with EN {
 
   Given("""I have {} {string} in my belly""") { (howMany: Int, what: String) =>
@@ -183,6 +185,7 @@ class CukesStepDefinitions extends ScalaDsl with EN {
   }
 }
 
+@nowarn
 class ThenDefs extends ScalaDsl with EN {
   Then("""^I am "([^"]*)"$""") { (arg0: String) =>
   }

--- a/scala/sources/src/test/scala/tests/cukes/TypeRegistryConfiguration.scala
+++ b/scala/sources/src/test/scala/tests/cukes/TypeRegistryConfiguration.scala
@@ -10,6 +10,9 @@ import io.cucumber.cucumberexpressions.{ParameterByTypeTransformer, ParameterTyp
 import io.cucumber.datatable.{DataTableType, TableCellByTypeTransformer, TableEntryByTypeTransformer, TableEntryTransformer}
 import tests.cukes.model.{Cukes, Person, Snake}
 
+import scala.annotation.nowarn
+
+@nowarn
 class TypeRegistryConfiguration extends TypeRegistryConfigurer {
 
   /**

--- a/scala/sources/src/test/scala/tests/object/ObjectSteps.scala
+++ b/scala/sources/src/test/scala/tests/object/ObjectSteps.scala
@@ -3,6 +3,9 @@ package tests.`object`
 import io.cucumber.scala.{EN, ScalaDsl}
 import org.junit.Assert.assertEquals
 
+import scala.annotation.nowarn
+
+@nowarn
 object ObjectSteps extends ScalaDsl with EN {
 
   private var calculator: Calculator = _


### PR DESCRIPTION
Fix #51 

Only applied for Scala 2.13 because it's easy to ignore some warnings with the `@nowarn` annotation and it's not that easy to do in 2.12 or 2.11 (need to use a compiler plugin but not sure how to plug it with Maven).