### PR TITLE
Add task and script to automatically update install doc on release

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,6 +28,11 @@ update-major-dependency-versions:
 	mvn versions:update-properties -DallowMajorUpdates=true -Dmaven.version.rules="file://`pwd`/.m2/maven-version-rules.xml"
 .PHONY: update-major-dependency-versions
 
+update-installdoc:
+	cat docs/install.md | ./scripts/update-install-doc.sh $(NEW_VERSION) > docs/install.md.tmp
+	mv docs/install.md.tmp docs/install.md
+.PHONY: update-installdoc
+
 update-changelog:
 	cat CHANGELOG.md | ./scripts/update-changelog.sh $(NEW_VERSION) > CHANGELOG.md.tmp
 	mv CHANGELOG.md.tmp CHANGELOG.md

--- a/Makefile
+++ b/Makefile
@@ -38,12 +38,12 @@ update-changelog:
 	mv CHANGELOG.md.tmp CHANGELOG.md
 .PHONY: update-changelog
 
-.commit-and-push-changelog:
-	git commit -am "Update CHANGELOG for v$(NEW_VERSION)"
+.commit-and-push-changelog-and-docs:
+	git commit -am "Update CHANGELOG and docs for v$(NEW_VERSION)"
 	git push
 .PHONY: .commit-and-push-changelog
 
-release: default update-changelog .commit-and-push-changelog
+release: default update-changelog update-installdoc .commit-and-push-changelog-and-docs
 	mvn --batch-mode release:clean release:prepare -DautoVersionSubmodules=true -Darguments="-DskipTests=true -DskipITs=true -Darchetype.test.skip=true"
 	git checkout "v$(NEW_VERSION)"
 	mvn deploy -P-examples -P-compatibility -Psign-source-javadoc -DskipTests=true -DskipITs=true -Darchetype.test.skip=true

--- a/scripts/update-install-doc.sh
+++ b/scripts/update-install-doc.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -uf -o pipefail
+
+# Reads installation doc from STDIN and writes out a new one to STDOUT where:
+#
+# * the version number is updated for both Maven and sbt
+#
+
+new_version=$1
+
+installdoc=$(</dev/stdin)
+
+# Maven
+installdoc=$(echo "${installdoc}" | sed "s/<version>[0-9]\+.[0-9]\+.[0-9]\+<\/version>/<version>${new_version}<\/version>/g")
+# sbt
+installdoc=$(echo "${installdoc}" | sed "s/% \"[0-9]\+.[0-9]\+.[0-9]\+\" %/% \"${new_version}\" %/g")
+
+# Output
+echo "${installdoc}"


### PR DESCRIPTION
- Add "task" in `Makefile` to update the `docs/install.md` file on release (same process as for the CHANGELOG)
- Add script to actually do the update using sed