### PR TITLE
Raise exceptions on incorrect hook definition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ See also the [CHANGELOG](https://github.com/cucumber/cucumber-jvm/blob/master/CH
 
 ### Fixed
 
+- [Scala DSL] Raise an exception at runtime if hooks are not correctly defined ([#60](https://github.com/cucumber/cucumber-jvm-scala/issues/60) Gaël Jourdan-Weil)
+
 ## [5.7.0] (2020-05-10)
 
 ### Added

--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -16,11 +16,13 @@ Scenario hooks run for every scenario.
 ```scala
 Before { scenario : Scenario =>
   // Do something before each scenario
+  // Must return Unit
 }
 
 // Or:
 Before {
   // Do something before each scenario
+  // Must return Unit
 }
 ```
 
@@ -31,11 +33,13 @@ Before {
 ```scala
 After { scenario : Scenario =>
   // Do something after each scenario
+  // Must return Unit
 }
 
 // Or:
 After {
   // Do something after each scenario
+  // Must return Unit
 }
 ```
 
@@ -48,11 +52,13 @@ Step hooks invoked before and after a step.
 ```scala
 BeforeStep { scenario : Scenario =>
   // Do something before step
+  // Must return Unit
 }
 
 // Or:
 BeforeStep {
   // Do something before step
+  // Must return Unit
 }
 ```
 
@@ -61,11 +67,13 @@ BeforeStep {
 ```scala
 AfterStep { scenario : Scenario =>
   // Do something after step
+  // Must return Unit
 }
 
 // Or:
 AfterStep {
   // Do something after step
+  // Must return Unit
 }
 ```
 
@@ -76,6 +84,7 @@ Hooks can be conditionally selected for execution based on the tags of the scena
 ```scala
 Before("@browser and not @headless") { 
   // Do something before each scenario with tag @browser but not @headless
+  // Must return Unit
 }
 ```
 
@@ -86,10 +95,12 @@ You can define an order between multiple hooks.
 ```scala
 Before(10) { 
   // Do something before each scenario
+  // Must return Unit
 }
 
 Before(20) { 
   // Do something before each scenario
+  // Must return Unit
 }
 ```
 
@@ -101,5 +112,6 @@ You mix up conditional and order hooks with following syntax:
 ```scala
 Before("@browser and not @headless", 10) {
   // Do something before each scenario
+  // Must return Unit
 }
 ```

--- a/scala/sources/src/main/scala/io/cucumber/scala/GlueAdaptor.scala
+++ b/scala/sources/src/main/scala/io/cucumber/scala/GlueAdaptor.scala
@@ -11,11 +11,17 @@ class GlueAdaptor(glue: Glue) {
    * @param scenarioScoped true for class instances, false for object singletons
    */
   def loadRegistry(registry: ScalaDslRegistry, scenarioScoped: Boolean): Unit = {
+
+    // If the registry is not consistent, this indicates a mistake in the users definition and we want to let him know.
+    registry.checkConsistency().left.foreach { ex: IncorrectHookDefinitionException =>
+      throw ex
+    }
+
     registry.stepDefinitions.map(ScalaStepDefinition(_, scenarioScoped)).foreach(glue.addStepDefinition)
     registry.beforeHooks.map(ScalaHookDefinition(_, scenarioScoped)).foreach(glue.addBeforeHook)
     registry.afterHooks.map(ScalaHookDefinition(_, scenarioScoped)).foreach(glue.addAfterHook)
-    registry.afterStepHooks.map(ScalaHookDefinition(_, scenarioScoped)).foreach(glue.addAfterStepHook)
     registry.beforeStepHooks.map(ScalaHookDefinition(_, scenarioScoped)).foreach(glue.addBeforeStepHook)
+    registry.afterStepHooks.map(ScalaHookDefinition(_, scenarioScoped)).foreach(glue.addAfterStepHook)
     registry.docStringTypes.map(ScalaDocStringTypeDefinition(_, scenarioScoped)).foreach(glue.addDocStringType)
     registry.dataTableTypes.map(ScalaDataTableTypeDefinition(_, scenarioScoped)).foreach(glue.addDataTableType)
     registry.parameterTypes.map(ScalaParameterTypeDefinition(_, scenarioScoped)).foreach(glue.addParameterType)

--- a/scala/sources/src/main/scala/io/cucumber/scala/IncorrectHookDefinitionException.scala
+++ b/scala/sources/src/main/scala/io/cucumber/scala/IncorrectHookDefinitionException.scala
@@ -1,0 +1,38 @@
+package io.cucumber.scala
+
+import io.cucumber.core.backend.CucumberBackendException
+
+object IncorrectHookDefinitionException {
+
+  def errorMessage(expectedHooks: Seq[UndefinedHook]): String = {
+    val hooksListToDisplay = expectedHooks.map { eh =>
+      s" - ${eh.stackTraceElement.getFileName}:${eh.stackTraceElement.getLineNumber} (${eh.hookType})"
+    }
+
+    s"""Some hooks are not defined properly:
+       |${hooksListToDisplay.mkString("\n")}
+       |
+       |This can be caused by defining hooks where the body returns a Int or String rather than Unit.
+       |
+       |For instance, the following code:
+       |
+       |  Before {
+       |    someInitMethodReturningInt()
+       |  }
+       |
+       |Should be replaced with:
+       |
+       |  Before {
+       |    someInitMethodReturningInt()
+       |    ()
+       |  }
+       |""".stripMargin
+  }
+
+}
+
+class IncorrectHookDefinitionException(val undefinedHooks: Seq[UndefinedHook]) extends CucumberBackendException(IncorrectHookDefinitionException.errorMessage(undefinedHooks)) {
+
+}
+
+case class UndefinedHook(hookType: HookType, stackTraceElement: StackTraceElement)

--- a/scala/sources/src/main/scala/io/cucumber/scala/ScalaDslRegistry.scala
+++ b/scala/sources/src/main/scala/io/cucumber/scala/ScalaDslRegistry.scala
@@ -1,30 +1,121 @@
 package io.cucumber.scala
 
-import scala.collection.mutable.ArrayBuffer
+import io.cucumber.scala.HookType.{AFTER, AFTER_STEP, BEFORE, BEFORE_STEP}
 
 class ScalaDslRegistry {
 
-  val stepDefinitions = new ArrayBuffer[ScalaStepDetails]
+  private var _stepDefinitions: Seq[ScalaStepDetails] = Seq()
 
-  val beforeHooks = new ArrayBuffer[ScalaHookDetails]
+  private var _beforeHooks: Seq[ScalaHookDetails] = Seq()
+  private var _beforeStepHooks: Seq[ScalaHookDetails] = Seq()
+  private var _afterHooks: Seq[ScalaHookDetails] = Seq()
+  private var _afterStepHooks: Seq[ScalaHookDetails] = Seq()
 
-  val beforeStepHooks = new ArrayBuffer[ScalaHookDetails]
+  private var _undefinedBeforeHooks: Seq[UndefinedHook] = Seq()
+  private var _undefinedBeforeStepHooks: Seq[UndefinedHook] = Seq()
+  private var _undefinedAfterHooks: Seq[UndefinedHook] = Seq()
+  private var _undefinedAfterStepHooks: Seq[UndefinedHook] = Seq()
 
-  val afterHooks = new ArrayBuffer[ScalaHookDetails]
+  private var _docStringTypes: Seq[ScalaDocStringTypeDetails[_]] = Seq()
 
-  val afterStepHooks = new ArrayBuffer[ScalaHookDetails]
+  private var _dataTableTypes: Seq[ScalaDataTableTypeDetails[_]] = Seq()
 
-  val docStringTypes = new ArrayBuffer[ScalaDocStringTypeDetails[_]]
+  private var _parameterTypes: Seq[ScalaParameterTypeDetails[_]] = Seq()
 
-  val dataTableTypes = new ArrayBuffer[ScalaDataTableTypeDetails[_]]
+  private var _defaultParameterTransformers: Seq[ScalaDefaultParameterTransformerDetails] = Seq()
 
-  val parameterTypes = new ArrayBuffer[ScalaParameterTypeDetails[_]]
+  private var _defaultDataTableCellTransformers: Seq[ScalaDefaultDataTableCellTransformerDetails] = Seq()
 
-  val defaultParameterTransformers = new ArrayBuffer[ScalaDefaultParameterTransformerDetails]
+  private var _defaultDataTableEntryTransformers: Seq[ScalaDefaultDataTableEntryTransformerDetails] = Seq()
 
-  val defaultDataTableCellTransformers = new ArrayBuffer[ScalaDefaultDataTableCellTransformerDetails]
+  def stepDefinitions: Seq[ScalaStepDetails] = _stepDefinitions
 
-  val defaultDataTableEntryTransformers = new ArrayBuffer[ScalaDefaultDataTableEntryTransformerDetails]
+  def beforeHooks: Seq[ScalaHookDetails] = _beforeHooks
+
+  def beforeStepHooks: Seq[ScalaHookDetails] = _beforeStepHooks
+
+  def afterHooks: Seq[ScalaHookDetails] = _afterHooks
+
+  def afterStepHooks: Seq[ScalaHookDetails] = _afterStepHooks
+
+  def docStringTypes: Seq[ScalaDocStringTypeDetails[_]] = _docStringTypes
+
+  def dataTableTypes: Seq[ScalaDataTableTypeDetails[_]] = _dataTableTypes
+
+  def parameterTypes: Seq[ScalaParameterTypeDetails[_]] = _parameterTypes
+
+  def defaultParameterTransformers: Seq[ScalaDefaultParameterTransformerDetails] = _defaultParameterTransformers
+
+  def defaultDataTableCellTransformers: Seq[ScalaDefaultDataTableCellTransformerDetails] = _defaultDataTableCellTransformers
+
+  def defaultDataTableEntryTransformers: Seq[ScalaDefaultDataTableEntryTransformerDetails] = _defaultDataTableEntryTransformers
+
+  def expectHook(hookType: HookType, stackTraceElement: StackTraceElement): Unit = {
+    hookType match {
+      case BEFORE =>
+        _undefinedBeforeHooks = _undefinedBeforeHooks :+ UndefinedHook(hookType, stackTraceElement)
+      case BEFORE_STEP =>
+        _undefinedBeforeStepHooks = _undefinedBeforeStepHooks :+ UndefinedHook(hookType, stackTraceElement)
+      case AFTER =>
+        _undefinedAfterHooks = _undefinedAfterHooks :+ UndefinedHook(hookType, stackTraceElement)
+      case AFTER_STEP =>
+        _undefinedAfterStepHooks = _undefinedAfterStepHooks :+ UndefinedHook(hookType, stackTraceElement)
+    }
+  }
+
+  def registerHook(hookType: HookType, details: ScalaHookDetails, frame: StackTraceElement): Unit = {
+    hookType match {
+      case HookType.BEFORE =>
+        _beforeHooks = _beforeHooks :+ details
+        _undefinedBeforeHooks = _undefinedBeforeHooks.filterNot(_.stackTraceElement == frame)
+      case HookType.BEFORE_STEP =>
+        _beforeStepHooks = _beforeStepHooks :+ details
+        _undefinedBeforeStepHooks = _undefinedBeforeStepHooks.filterNot(_.stackTraceElement == frame)
+      case HookType.AFTER =>
+        _afterHooks = _afterHooks :+ details
+        _undefinedAfterHooks = _undefinedAfterHooks.filterNot(_.stackTraceElement == frame)
+      case HookType.AFTER_STEP =>
+        _afterStepHooks = _afterStepHooks :+ details
+        _undefinedAfterStepHooks = _undefinedAfterStepHooks.filterNot(_.stackTraceElement == frame)
+    }
+  }
+
+  def registerStep(details: ScalaStepDetails): Unit = {
+    _stepDefinitions = _stepDefinitions :+ details
+  }
+
+  def registerDocStringType[T](details: ScalaDocStringTypeDetails[T]): Unit = {
+    _docStringTypes = _docStringTypes :+ details
+  }
+
+  def registerDataTableType[T](details: ScalaDataTableTypeDetails[T]): Unit = {
+    _dataTableTypes = _dataTableTypes :+ details
+  }
+
+  def registerParameterType[R](details: ScalaParameterTypeDetails[R]): Unit = {
+    _parameterTypes = _parameterTypes :+ details
+  }
+
+  def registerDefaultDataTableCellTransformer(details: ScalaDefaultDataTableCellTransformerDetails): Unit = {
+    _defaultDataTableCellTransformers = _defaultDataTableCellTransformers :+ details
+  }
+
+  def registerDefaultDataTableEntryTransformer(details: ScalaDefaultDataTableEntryTransformerDetails): Unit = {
+    _defaultDataTableEntryTransformers = _defaultDataTableEntryTransformers :+ details
+  }
+
+  def registerDefaultParameterTransformer(details: ScalaDefaultParameterTransformerDetails): Unit = {
+    _defaultParameterTransformers = _defaultParameterTransformers :+ details
+  }
+
+  def checkConsistency(): Either[IncorrectHookDefinitionException, Unit] = {
+    val undefinedHooks = _undefinedBeforeHooks ++ _undefinedBeforeStepHooks ++ _undefinedAfterHooks ++ _undefinedAfterStepHooks
+    if (undefinedHooks.nonEmpty) {
+      Left(new IncorrectHookDefinitionException(undefinedHooks))
+    } else {
+      Right(())
+    }
+  }
 
 }
 

--- a/scala/sources/src/main/scala/io/cucumber/scala/Utils.scala
+++ b/scala/sources/src/main/scala/io/cucumber/scala/Utils.scala
@@ -9,7 +9,8 @@ private[scala] object Utils {
   def frame(self: Any): StackTraceElement = {
     val frames = Thread.currentThread().getStackTrace
     val currentClass = self.getClass.getName
-    frames.find(_.getClassName == currentClass).get
+    // Note: the -1 check is here for Scala < 2.13 and objects
+    frames.reverse.find(f => f.getClassName == currentClass && f.getLineNumber != -1).get
   }
 
 }

--- a/scala/sources/src/test/scala/io/cucumber/scala/steps/errors/incorrectclasshooks/IncorrectClassHooksDefinition.scala
+++ b/scala/sources/src/test/scala/io/cucumber/scala/steps/errors/incorrectclasshooks/IncorrectClassHooksDefinition.scala
@@ -1,0 +1,23 @@
+package io.cucumber.scala.steps.errors.incorrectclasshooks
+
+import io.cucumber.scala.ScalaDsl
+
+//@formatter:off
+class IncorrectClassHooksDefinition extends ScalaDsl {
+
+  // On a single line to avoid difference between Scala versions for the location
+
+  // A body that does not return Unit => interpreted as missing body
+  Before { 1 }
+
+  // A body that does not return Unit => interpreted as missing body
+  BeforeStep { "toto" }
+
+  // A body that does not return Unit => interpreted as missing body
+  After { 33 }
+
+  // A body that does not return Unit => interpreted as missing body
+  AfterStep { "toto" }
+
+}
+//@formatter:on

--- a/scala/sources/src/test/scala/io/cucumber/scala/steps/errors/incorrectobjecthooks/IncorrectObjectHooksDefinition.scala
+++ b/scala/sources/src/test/scala/io/cucumber/scala/steps/errors/incorrectobjecthooks/IncorrectObjectHooksDefinition.scala
@@ -1,0 +1,23 @@
+package io.cucumber.scala.steps.errors.incorrectobjecthooks
+
+import io.cucumber.scala.ScalaDsl
+
+//@formatter:off
+object IncorrectObjectHooksDefinition extends ScalaDsl {
+
+  // On a single line to avoid difference between Scala versions for the location
+
+  // A body that does not return Unit => interpreted as missing body
+  Before { 1 }
+
+  // A body that does not return Unit => interpreted as missing body
+  BeforeStep { "toto" }
+
+  // A body that does not return Unit => interpreted as missing body
+  After { 33 }
+
+  // A body that does not return Unit => interpreted as missing body
+  AfterStep { "toto" }
+
+}
+//@formatter:on


### PR DESCRIPTION
Aims to fix #60 

If an incorrect hook is defined and this cannot be caught at compile time, then an exception is raised at runtime with a message similar to this:
```
Some hooks are not defined properly:
 - IncorrectClassHooksDefinition.scala:11 (BEFORE)
 - IncorrectClassHooksDefinition.scala:14 (BEFORE_STEP)
 - IncorrectClassHooksDefinition.scala:17 (AFTER)
 - IncorrectClassHooksDefinition.scala:20 (AFTER_STEP)

This can be caused by defining hooks where the body returns a Int or String rather than Unit.

For instance, the following code:

  Before {
    someInitMethodReturningInt()
  }

Should be replaced with:

  Before {
    someInitMethodReturningInt()
    ()
  }
```

-----

This PR also include a small refactoring of the `GlueRegistry` to use immutable types with `private var` rather than mutable types with `public val`. The former avoid to leak a mutable type outside.