### PR TITLE
Add tests to highlight mapping of optional capture groups

### DIFF
--- a/scala/sources/src/test/resources/tests/misc/OptionalCaptureGroups.feature
+++ b/scala/sources/src/test/resources/tests/misc/OptionalCaptureGroups.feature
@@ -1,0 +1,7 @@
+Feature: Optional capture groups are supported
+
+  Scenario: present, using Java's Optional
+    Given I have the name: Jack
+
+  Scenario: absent, using Java's Optional
+    Given I don't have the name:

--- a/scala/sources/src/test/scala/tests/misc/OptionalCaptureGroupsSteps.scala
+++ b/scala/sources/src/test/scala/tests/misc/OptionalCaptureGroupsSteps.scala
@@ -1,0 +1,35 @@
+package tests.misc
+
+import java.util.Optional
+
+import io.cucumber.scala.{EN, ScalaDsl}
+
+class OptionalCaptureGroupsSteps extends ScalaDsl with EN {
+
+  // Scala 2.13 only
+  // import scala.jdk.OptionConverters._
+
+  import OptionalCaptureGroupsSteps._
+
+  Given("""^I have the name:\s?(.+)?$""") { (name: Optional[String]) =>
+    val option = name.toScala
+    assert(option.isDefined)
+    assert(option.getOrElse("Nope") == "Jack")
+  }
+
+  Given("""^I don't have the name:\s?(.+)?$""") { (name: Optional[String]) =>
+    val option = name.toScala
+    assert(option.isEmpty)
+  }
+
+}
+
+object OptionalCaptureGroupsSteps {
+
+  implicit class RichOptional[A](private val o: java.util.Optional[A]) extends AnyVal {
+
+    def toScala: Option[A] = if (o.isPresent) Some(o.get) else None
+
+  }
+
+}

--- a/scala/sources/src/test/scala/tests/misc/RunMiscTest.scala
+++ b/scala/sources/src/test/scala/tests/misc/RunMiscTest.scala
@@ -1,0 +1,8 @@
+package tests.misc
+
+import io.cucumber.junit.{Cucumber, CucumberOptions}
+import org.junit.runner.RunWith
+
+@RunWith(classOf[Cucumber])
+@CucumberOptions(strict = true)
+class RunMiscTest


### PR DESCRIPTION
Relates to #3 

This PR just add a test to highlight that it's possible to use optional capture groups as Java's `Optional` and map them again to Scala's `Option`.
