### PR TITLE
Remove deprecated tests

### DIFF
--- a/scala/scala_2.11/pom.xml
+++ b/scala/scala_2.11/pom.xml
@@ -85,6 +85,8 @@
                     <args>
                         <arg>-deprecation</arg>
                         <arg>-feature</arg>
+                        <!-- Allow definition of implicit functions called views -->
+                        <arg>-language:implicitConversions</arg>
                     </args>
                     <excludes>
                         <exclude>**/*.java</exclude>

--- a/scala/scala_2.12/pom.xml
+++ b/scala/scala_2.12/pom.xml
@@ -78,6 +78,8 @@
                         <arg>-deprecation</arg>
                         <!-- Emit warning and location for usages of features that should be imported explicitly. -->
                         <arg>-feature</arg>
+                        <!-- Allow definition of implicit functions called views -->
+                        <arg>-language:implicitConversions</arg>
                     </args>
                     <excludes>
                         <exclude>**/*.java</exclude>

--- a/scala/sources/src/test/scala/tests/cukes/RunCukesTest.scala
+++ b/scala/sources/src/test/scala/tests/cukes/RunCukesTest.scala
@@ -4,5 +4,5 @@ import io.cucumber.junit.{Cucumber, CucumberOptions}
 import org.junit.runner.RunWith
 
 @RunWith(classOf[Cucumber])
-@CucumberOptions(strict = true)
+@CucumberOptions()
 class RunCukesTest

--- a/scala/sources/src/test/scala/tests/cukes/TypeRegistryConfiguration.scala
+++ b/scala/sources/src/test/scala/tests/cukes/TypeRegistryConfiguration.scala
@@ -1,115 +1,41 @@
 package tests.cukes
 
-import java.lang.reflect.Type
-import java.util
-import java.util.{Locale, Map => JMap}
-
-import com.fasterxml.jackson.databind.ObjectMapper
-import io.cucumber.core.api.{TypeRegistry, TypeRegistryConfigurer}
-import io.cucumber.cucumberexpressions.{ParameterByTypeTransformer, ParameterType, Transformer}
-import io.cucumber.datatable.{DataTableType, TableCellByTypeTransformer, TableEntryByTypeTransformer, TableEntryTransformer}
+import io.cucumber.scala.ScalaDsl
 import tests.cukes.model.{Cukes, Person, Snake}
 
-import scala.annotation.nowarn
-
-@nowarn
-class TypeRegistryConfiguration extends TypeRegistryConfigurer {
+class TypeRegistryConfiguration extends ScalaDsl {
 
   /**
-    * Transforms an ASCII snake into an object, for example:
-    *
-    * {{{
-    *  ====>  becomes Snake(length = 5, direction = 'east)
-    *    ==>  becomes Snake(length = 3, direction = 'east)
-    * }}}
-    */
-  private val snakeTransformer = new Transformer[Snake]() {
-    def transform(s: String) = {
-      val size = s.size
-      val direction = s.toList match {
-        case '<' :: _ => Symbol("west")
-        case l if l.last == '>' => Symbol("east")
-      }
-      Snake(size, direction)
+   * Transforms an ASCII snake into an object, for example:
+   *
+   * {{{
+   *  ====>  becomes Snake(length = 5, direction = 'east)
+   *    ==>  becomes Snake(length = 3, direction = 'east)
+   * }}}
+   */
+  ParameterType("snake", "[=><]+") { s =>
+    val size = s.length
+    val direction = s.toList match {
+      case '<' :: _ => Symbol("west")
+      case l if l.last == '>' => Symbol("east")
     }
+    Snake(size, direction)
   }
 
-  private val personTransformer = new Transformer[Person]() {
-    def transform(s: String) = {
-      Person(s)
-    }
+  ParameterType("person", ".+") { s =>
+    Person(s)
   }
 
-  private val booleanTransformer = new Transformer[Boolean]() {
-    def transform(s: String) = {
-      s.trim.equals("true")
-    }
+  ParameterType("boolean", "true|false") { s =>
+    s.trim.equals("true")
   }
 
-  private val charTransformer = new Transformer[Char]() {
-    def transform(s: String) = {
-      s.charAt(0)
-    }
+  ParameterType("char", ".") { s =>
+    s.charAt(0)
   }
 
-  private val listTransformer  =new TableEntryTransformer[Cukes]() {
-    override def transform(map: util.Map[String, String]): Cukes = {
-      new Cukes(map.get("Number").toInt, map.get("Color"))
-    }
-  }
-
-  override def locale(): Locale = Locale.ENGLISH
-
-  override def configureTypeRegistry(typeRegistry: TypeRegistry): Unit = {
-    val defaultTransformer = new DefaultTransformer()
-    typeRegistry.setDefaultDataTableCellTransformer(defaultTransformer)
-    typeRegistry.setDefaultDataTableEntryTransformer(defaultTransformer)
-    typeRegistry.setDefaultParameterTransformer(defaultTransformer)
-
-    typeRegistry.defineParameterType(new ParameterType[Snake](
-      "snake",
-      "[=><]+",
-      classOf[Snake],
-      snakeTransformer
-    ))
-
-    typeRegistry.defineParameterType(new ParameterType[Person](
-      "person",
-      ".+",
-      classOf[Person],
-      personTransformer
-    ))
-
-    typeRegistry.defineParameterType(new ParameterType[Boolean](
-      "boolean",
-      "true|false",
-      classOf[Boolean],
-      booleanTransformer
-    ))
-
-    typeRegistry.defineParameterType(new ParameterType[Char](
-      "char",
-      ".",
-      classOf[Char],
-      charTransformer
-    ))
-
-    typeRegistry.defineDataTableType(new DataTableType(classOf[Cukes],listTransformer))
-  }
-  private class DefaultTransformer
-    extends ParameterByTypeTransformer
-      with TableEntryByTypeTransformer
-      with TableCellByTypeTransformer {
-
-    var objectMapper: ObjectMapper = new ObjectMapper()
-
-    override def transform(s: String, `type`: Type): AnyRef =
-      objectMapper.convertValue(s, objectMapper.constructType(`type`))
-
-    override def transform(map: JMap[String, String], `type`: Type, tableCellByTypeTransformer: TableCellByTypeTransformer): AnyRef = {
-      objectMapper.convertValue(map, objectMapper.constructType(`type`))
-    }
-
+  DataTableType { map: Map[String, String] =>
+    Cukes(map("Number").toInt, map("Color"))
   }
 
 }

--- a/scala/sources/src/test/scala/tests/datatables/RunDatatablesTest.scala
+++ b/scala/sources/src/test/scala/tests/datatables/RunDatatablesTest.scala
@@ -4,5 +4,5 @@ import io.cucumber.junit.{Cucumber, CucumberOptions}
 import org.junit.runner.RunWith
 
 @RunWith(classOf[Cucumber])
-@CucumberOptions(strict = true)
+@CucumberOptions()
 class RunDatatablesTest

--- a/scala/sources/src/test/scala/tests/docstring/RunDocStringTest.scala
+++ b/scala/sources/src/test/scala/tests/docstring/RunDocStringTest.scala
@@ -4,5 +4,5 @@ import io.cucumber.junit.{Cucumber, CucumberOptions}
 import org.junit.runner.RunWith
 
 @RunWith(classOf[Cucumber])
-@CucumberOptions(strict = true)
+@CucumberOptions()
 class RunDocStringTest

--- a/scala/sources/src/test/scala/tests/isolated/RunIsolatedTest.scala
+++ b/scala/sources/src/test/scala/tests/isolated/RunIsolatedTest.scala
@@ -4,5 +4,5 @@ import io.cucumber.junit.{Cucumber, CucumberOptions}
 import org.junit.runner.RunWith
 
 @RunWith(classOf[Cucumber])
-@CucumberOptions(strict = true)
+@CucumberOptions()
 class RunIsolatedTest

--- a/scala/sources/src/test/scala/tests/jackson/RunJacksonTest.scala
+++ b/scala/sources/src/test/scala/tests/jackson/RunJacksonTest.scala
@@ -4,5 +4,5 @@ import io.cucumber.junit.{Cucumber, CucumberOptions}
 import org.junit.runner.RunWith
 
 @RunWith(classOf[Cucumber])
-@CucumberOptions(strict = true)
+@CucumberOptions()
 class RunJacksonTest

--- a/scala/sources/src/test/scala/tests/misc/RunMiscTest.scala
+++ b/scala/sources/src/test/scala/tests/misc/RunMiscTest.scala
@@ -4,5 +4,5 @@ import io.cucumber.junit.{Cucumber, CucumberOptions}
 import org.junit.runner.RunWith
 
 @RunWith(classOf[Cucumber])
-@CucumberOptions(strict = true)
+@CucumberOptions()
 class RunMiscTest

--- a/scala/sources/src/test/scala/tests/object/RunObjectTest.scala
+++ b/scala/sources/src/test/scala/tests/object/RunObjectTest.scala
@@ -4,5 +4,5 @@ import io.cucumber.junit.{Cucumber, CucumberOptions}
 import org.junit.runner.RunWith
 
 @RunWith(classOf[Cucumber])
-@CucumberOptions(strict = true)
+@CucumberOptions()
 class RunObjectTest

--- a/scala/sources/src/test/scala/tests/parametertypes/RunParameterTypesTest.scala
+++ b/scala/sources/src/test/scala/tests/parametertypes/RunParameterTypesTest.scala
@@ -4,5 +4,5 @@ import io.cucumber.junit.{Cucumber, CucumberOptions}
 import org.junit.runner.RunWith
 
 @RunWith(classOf[Cucumber])
-@CucumberOptions(strict = true)
+@CucumberOptions()
 class RunParameterTypesTest


### PR DESCRIPTION
- Remove `strict` flag on `CucumberOptions` as it's now the default since Cucumber 6.x
- Remove `TypeRegistryConfigurer` tests as it's been deprecated since 5.x