### PR TITLE
Add asScalaRaw extension methods to DataTable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ See also the [CHANGELOG](https://github.com/cucumber/cucumber-jvm/blob/master/CH
 
 ### Added
 
+- Add `asScalaRawList[T]`, `asScalaRawMaps[T]` and `asScalaRawLists[T]` on `DataTable` (through `io.cucumber.scala.Implicits`) ([#83](https://github.com/cucumber/cucumber-jvm-scala/issues/83) Gaël Jourdan-Weil)
+
 ### Changed
 
 ### Deprecated

--- a/docs/datatables.md
+++ b/docs/datatables.md
@@ -8,6 +8,8 @@ Cucumber Scala support DataTables with either:
 
 See below the exhaustive list of possible mappings.
 
+_Note: you can use [transformers](transformers.md) to map DataTables to custom types._ 
+
 ## As Map of Map
 
 ```gherkin

--- a/docs/transformers.md
+++ b/docs/transformers.md
@@ -113,13 +113,15 @@ Given the following authors
 ```
 
 ```scala
-Given("the following authors") { (authors: java.util.List[Author]) =>
-  // Do something
+import io.cucumber.scala.Implicits._
+
+Given("the following authors") { (table: DataTable) =>
+  val authors = table.asScalaRawList[Author]
 }
 
-// Or using DataTable
-Given("the following authors") { (table: DataTable) =>
-  val authors = table.asList[Author](classOf[Author])
+// Or using Java type
+Given("the following authors") { (authors: java.util.List[Author]) =>
+  // Do something
 }
 ```
 
@@ -142,13 +144,15 @@ Given the following authors
 ```
 
 ```scala
-Given("the following authors") { (authors: java.util.List[Author]) =>
-  // Do something
+import io.cucumber.scala.Implicits._
+
+Given("the following authors") { (table: DataTable) =>
+  val authors = table.asScalaRawList[Author]
 }
 
-// Or using DataTable
-Given("the following authors") { (table: DataTable) =>
-  val authors = table.asList[Author](classOf[Author])
+// Or using Java types
+Given("the following authors") { (authors: java.util.List[Author]) =>
+  // Do something
 }
 ```
 
@@ -156,14 +160,14 @@ Given("the following authors") { (table: DataTable) =>
 
 For instance, the following transformer can be defined:
 ```scala
+import io.cucumber.scala.Implicits._
+
 case class Author(name: String, surname: String, famousBook: String)
 case class GroupOfAuthor(authors: Seq[Author])
 
 DataTableType { table: DataTable =>
-  val authors = table.asMaps().asScala
-      .map(_.asScala)
-      .map(entry => Author(entry("name"), entry("surname"), entry("famousBook")))
-      .toSeq
+  val authors = table.asScalaMaps
+      .map(entry => Author(entry("name").getOrElse(""), entry("surname").getOrElse(""), entry("famousBook").getOrElse("")))
   GroupOfAuthor(authors)
 }
 ```
@@ -204,13 +208,15 @@ Given the following authors
 ```
 
 ```scala
-Given("the following authors") { (authors: java.util.List[java.util.List[RichCell]]) =>
-  // Do something
+import io.cucumber.scala.Implicits._
+
+Given("the following authors") { (table: DataTable) =>
+  val authors = table.asScalaRawLists[RichCell]
 }
 
-// Or using DataTable
-Given("the following authors") { (table: DataTable) =>
-  val authors = table.asLists[RichCell](classOf[RichCell]))
+// Or using Java types
+Given("the following authors") { (authors: java.util.List[java.util.List[RichCell]]) =>
+  // Do something
 }
 ```
 
@@ -223,13 +229,15 @@ Given the following authors
 ```
 
 ```scala
-Given("the following authors") { (authors: java.util.List[java.util.Map[String, RichCell]]) =>
-  // Do something
+import io.cucumber.scala.Implicits._
+
+Given("the following authors") { (table: DataTable) =>
+  val authors = table.asScalaRawMaps[String, RichCell]
 }
 
-// Or using DataTable
-Given("the following authors") { (table: DataTable) =>
-  val authors = table.asMaps[String, RichCell](classOf[String], classOf[RichCell])
+// Or with Java Types
+Given("the following authors") { (authors: java.util.List[java.util.Map[String, RichCell]]) =>
+  // Do something
 }
 ```
 
@@ -296,13 +304,15 @@ DefaultDataTableEntryTransformer("[empty]") { (fromValue: Map[String, String], t
 
 Will be used to convert with such step definitions:
 ```scala
-Given("A step with a datatable") { (rows: java.util.List[SomeType]) =>
-  // Do something
+import io.cucumber.scala.Implicits._
+
+Given("A step with a datatable") { (dataTable: DataTable) =>
+  val table = dataTable.asScalaRawList[SomeType]
 }
 
-// Or DataTable
-Given("A step with a datatable") { (dataTable: DataTable) =>
-  val table = dataTable.asList[SomeType](classOf[SomeType])
+// Or with Java types
+Given("A step with a datatable") { (rows: java.util.List[SomeType]) =>
+  // Do something
 }
 ```
 
@@ -319,12 +329,14 @@ DefaultDataTableCellTransformer("[empty]") { (fromValue: String, toValueType: ja
 
 Will be used to convert with such step definitions:
 ```scala
-Given("A step with a datatable") { (rows: java.util.List[java.util.List[SomeType]]) =>
-  // Do something
+import io.cucumber.scala.Implicits._
+
+Given("A step with a datatable") { (dataTable: DataTable) =>
+  val table = dataTable.asScalaRawLists[SomeType]
 }
 
-// Or DataTable
-Given("A step with a datatable") { (dataTable: DataTable) =>
-  val table = dataTable.asLists[SomeType](classOf[SomeType])
+// Or with Java Types
+Given("A step with a datatable") { (rows: java.util.List[java.util.List[SomeType]]) =>
+  // Do something
 }
 ```

--- a/scala/sources/src/main/scala/io/cucumber/scala/Implicits.scala
+++ b/scala/sources/src/main/scala/io/cucumber/scala/Implicits.scala
@@ -23,6 +23,8 @@ object Implicits {
      * Provides a view of the DataTable as a sequence of rows, each row being a key-value map where key is the column name.
      * Equivalent of `.asMaps[K,V](classOf[K], classOf[V])` but returned as Scala collection types without `null` values.
      *
+     * See also `asScalaRawMaps[T]` if you don't need `Option`s (for instance if you are using a DataTableType).
+     *
      * @tparam K key type
      * @tparam V value type
      * @return sequence of rows
@@ -43,6 +45,23 @@ object Implicits {
     def asScalaMaps: Seq[Map[String, Option[String]]] = asScalaMaps[String, String]
 
     /**
+     * Provides a view of the DataTable as a sequence of rows, each row being a key-value map where key is the column name.
+     * Equivalent of `.asMaps[K,V](classOf[K], classOf[V])` but returned as Scala collection types.
+     *
+     * See also `asScalaMaps[T]`.
+     *
+     * @tparam K key type
+     * @tparam V value type
+     * @return sequence of rows
+     */
+    def asScalaRawMaps[K, V](implicit evK: ClassTag[K], evV: ClassTag[V]): Seq[Map[K, V]] = {
+      table.asMaps[K, V](evK.runtimeClass, evV.runtimeClass)
+        .asScala
+        .map(_.asScala.toMap)
+        .toSeq
+    }
+
+    /**
      * Provides a view of the DataTable as a key-value map where key are the first column values.
      * Equivalent of `.asMap[K,V](classOf[K],classOf[V])` but returned as Scala collection types without `null` values.
      *
@@ -60,6 +79,8 @@ object Implicits {
     /**
      * Provides a view of the DataTable as a matrix.
      * Equivalent of `.asLists[T](classOf[T])` but returned as Scala collection types without `null` values.
+     *
+     * See also `asScalaRawLists[T]` if you don't need `Option`s (for instance if you are using a DataTableType).
      *
      * @tparam T cell type
      * @return matrix
@@ -80,8 +101,26 @@ object Implicits {
     def asScalaLists: Seq[Seq[Option[String]]] = asScalaLists[String]
 
     /**
+     * Provides a view of the DataTable as a matrix.
+     * Equivalent of `.asLists[T](classOf[T])` but returned as Scala collection types.
+     *
+     * See also `asScalaLists[T]`
+     *
+     * @tparam T cell type
+     * @return matrix
+     */
+    def asScalaRawLists[T](implicit ev: ClassTag[T]): Seq[Seq[T]] = {
+      table.asLists[T](ev.runtimeClass)
+        .asScala
+        .map(_.asScala.toSeq)
+        .toSeq
+    }
+
+    /**
      * Provides a view of the DataTable as a simple list of values.
      * Equivalent of `.asList[T](classOf[T])` but returned as Scala collection types without `null` values.
+     *
+     * See also `asScalaRawList[T]` if you don't need `Option`s (for instance if you are using a DataTableType).
      *
      * @tparam T cell type
      * @return list of values
@@ -100,6 +139,21 @@ object Implicits {
      * @return list of values
      */
     def asScalaList: Seq[Option[String]] = asScalaList[String]
+
+    /**
+     * Provides a view of the DataTable as a simple list of values.
+     * Equivalent of `.asList[T](classOf[T])` but returned as Scala collection types.
+     *
+     * See also `asScalaList[T]`.
+     *
+     * @tparam T cell/row type
+     * @return list of values
+     */
+    def asScalaRawList[T](implicit ev: ClassTag[T]): Seq[T] = {
+      table.asList[T](ev.runtimeClass)
+        .asScala
+        .toSeq
+    }
 
     /**
      * Provides a view of the DataTable as a full table: a key-value map of row where keys are the first column values

--- a/scala/sources/src/test/resources/tests/datatables/DatatableAsScala.feature
+++ b/scala/sources/src/test/resources/tests/datatables/DatatableAsScala.feature
@@ -93,3 +93,26 @@ Feature: As Cucumber Scala, I want to parse DataTables to Scala types properly
       | 11 |
       |    |
       | 31 |
+
+    # With custom types using DatatableType
+
+  Scenario: As List of custom type
+    Given the following table as Scala List of custom type
+      | key1  | key2  | key3  |
+      | val11 | val12 | val13 |
+      | val21 |       | val23 |
+      | val31 | val32 | val33 |
+
+  Scenario: As List of List of custom type
+    Given the following table as Scala List of List of custom type
+      | val11 | val12 | val13 |
+      | val21 |       | val23 |
+      | val31 | val32 | val33 |
+
+  Scenario: As List of Map of custom type
+    Given the following table as Scala List of Map of custom type
+      | key1  | key2  | key3  |
+      | val11 | val12 | val13 |
+      | val21 |       | val23 |
+      | val31 | val32 | val33 |
+

--- a/scala/sources/src/test/scala/tests/datatables/DatatableAsScalaSteps.scala
+++ b/scala/sources/src/test/scala/tests/datatables/DatatableAsScalaSteps.scala
@@ -146,4 +146,47 @@ class DatatableAsScalaSteps extends ScalaDsl with EN {
     assert(data == expected)
   }
 
+  case class CustomType(key1: String, key2: Option[String], key3: String)
+
+  DataTableType { map: Map[String, String] =>
+    CustomType(map("key1"), Option(map("key2")), map("key3"))
+  }
+
+  Given("the following table as Scala List of custom type") { (table: DataTable) =>
+    val data: Seq[CustomType] = table.asScalaRawList[CustomType]
+    val expected = Seq(
+      CustomType("val11", Some("val12"), "val13"),
+      CustomType("val21", None, "val23"),
+      CustomType("val31", Some("val32"), "val33")
+    )
+    assert(data == expected)
+  }
+
+  case class RichCell(content: Option[String])
+
+  DataTableType { cell: String =>
+    RichCell(Option(cell))
+  }
+
+  Given("the following table as Scala List of List of custom type") { (table: DataTable) =>
+    val data: Seq[Seq[RichCell]] = table.asScalaRawLists[RichCell]
+    val expected = Seq(
+      Seq(RichCell(Some("val11")), RichCell(Some("val12")), RichCell(Some("val13"))),
+      Seq(RichCell(Some("val21")), RichCell(None), RichCell(Some("val23"))),
+      Seq(RichCell(Some("val31")), RichCell(Some("val32")), RichCell(Some("val33")))
+    )
+    assert(data == expected)
+  }
+
+  Given("the following table as Scala List of Map of custom type") { (table: DataTable) =>
+    val data: Seq[Map[String, RichCell]] = table.asScalaRawMaps[String, RichCell]
+    val expected = Seq(
+      Map("key1" -> RichCell(Some("val11")), "key2" -> RichCell(Some("val12")), "key3" -> RichCell(Some("val13"))),
+      Map("key1" -> RichCell(Some("val21")), "key2" -> RichCell(None), "key3" -> RichCell(Some("val23"))),
+      Map("key1" -> RichCell(Some("val31")), "key2" -> RichCell(Some("val32")), "key3" -> RichCell(Some("val33")))
+    )
+    assert(data == expected)
+
+  }
+
 }


### PR DESCRIPTION
Aims to resolve #83 

Add `asScalaRawXxx` methods to transform DataTable to collections _without_ `Option`s when it's not necessary.

For instance:
```scala
DataTableType { map: Map[String, String] =>
  CustomType(map("key1"), Option(map("key2")), map("key3"))
}

Given("the following table as Scala List of custom type") { (table: DataTable) =>
  val data: Seq[CustomType] = table.asScalaRawList[CustomType]
  // Do something..
}
```