### PR TITLE
Add new DataTableType definitions with Option input values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ See also the [CHANGELOG](https://github.com/cucumber/cucumber-jvm/blob/master/CH
 ### Added
 
 - Add `asScalaRawList[T]`, `asScalaRawMaps[T]` and `asScalaRawLists[T]` on `DataTable` (through `io.cucumber.scala.Implicits`) ([#83](https://github.com/cucumber/cucumber-jvm-scala/issues/83) Gaël Jourdan-Weil)
+- Add new `DataTableType` definitions with optional input values ([#84](https://github.com/cucumber/cucumber-jvm-scala/issues/84) Gaël Jourdan-Weil)
+  - `DataTableType { (entry: Map[String, Option[String]]) => ... }`
+  - `DataTableType { (row: Seq[Option[String]]) => ... }`
+  - `DataTableType { (cell: Option[String]) => ... }`
 
 ### Changed
 

--- a/docs/transformers.md
+++ b/docs/transformers.md
@@ -87,7 +87,7 @@ This can be achieved in different ways:
 - transform cells content to any type
 
 Note that DataTables in Gherkin can not represent `null` or the empty string unambiguously.
-Cucumber will interpret empty cells as `null`.
+Cucumber will interpret empty cells as `None` or `null`.
 But you can use a replacement to represent empty strings.
 See below.
 
@@ -99,8 +99,8 @@ For instance, the following transformer can be defined:
 ```scala
 case class Author(name: String, surname: String, famousBook: String)
 
-DataTableType { entry: Map[String, String] =>
-  Author(entry("name"), entry("surname"), entry("famousBook"))
+DataTableType { entry: Map[String, Option[String]] => // Or Map[String, String]
+  Author(entry("name").getOrElse("NoValue"), entry("surname").getOrElse("NoValue"), entry("famousBook").getOrElse("NoValue"))
 }
 ```
 
@@ -131,8 +131,8 @@ For instance, the following transformer can be defined:
 ```scala
 case class Author(name: String, surname: String, famousBook: String)
 
-DataTableType { row: Seq[String] =>
-  Author(row(0), row(1), row(2))
+DataTableType { row: Seq[Option[String]] => // Or Seq[String]
+  Author(row(0).getOrElse("NoValue"), row(1).getOrElse("NoValue"), row(2).getOrElse("NoValue"))
 }
 ```
 
@@ -166,8 +166,10 @@ case class Author(name: String, surname: String, famousBook: String)
 case class GroupOfAuthor(authors: Seq[Author])
 
 DataTableType { table: DataTable =>
-  val authors = table.asScalaMaps
-      .map(entry => Author(entry("name").getOrElse(""), entry("surname").getOrElse(""), entry("famousBook").getOrElse("")))
+  val authors = table.asMaps().asScala
+      .map(_.asScala)
+      .map(entry => Author(entry("name"), entry("surname"), entry("famousBook")))
+      .toSeq
   GroupOfAuthor(authors)
 }
 ```
@@ -195,8 +197,8 @@ For instance, the following transformer can be defined:
 ```scala
 case class RichCell(content: String)
 
-DataTableType { cell: String =>
-  RichCell(cell)
+DataTableType { cell: Option[String] => // Or String
+  RichCell(cell.getOrElse("NoValue"))
 }
 ```
 
@@ -243,7 +245,7 @@ Given("the following authors") { (authors: java.util.List[java.util.Map[String, 
 
 ### Empty values
 
-By default empty values in DataTable are treated as `null` by Cucumber.
+By default empty values in DataTable are treated as `None` or `null` by Cucumber.
 If you need to have empty values, you can define a replacement like `[empty]` that will be automatically replaced to empty when parsing DataTable.
 
 To do so, you can add a parameter to a `DataTableType` definition.
@@ -252,7 +254,7 @@ For instance, with the following definition:
 ```scala
 case class Author(name: String, surname: String, famousBook: String)
 
-DataTableType("[empty]") { (entry: Map[String, String]) =>
+DataTableType("[empty]") { (entry: Map[String, String]) => // Or Map[String, Option[String]]
   Author(entry("name"), entry("surname"), entry("famousBook"))
 }
 ```

--- a/scala/scala_2.11/src/main/scala/io/cucumber/scala/package.scala
+++ b/scala/scala_2.11/src/main/scala/io/cucumber/scala/package.scala
@@ -21,16 +21,25 @@ package object scala {
     override def transform(entry: Map[String, String]): T = f.apply(entry)
   }
 
+  implicit def function1AsDataTableOptionalEntryDefinitionBody[T](f: (Map[String, Option[String]]) => T): DataTableOptionalEntryDefinitionBody[T] = new DataTableOptionalEntryDefinitionBody[T] {
+    override def transform(entry: Map[String, Option[String]]): T = f.apply(entry)
+  }
 
   implicit def function1AsDataTableRowDefinitionBody[T](f: (Seq[String]) => T): DataTableRowDefinitionBody[T] = new DataTableRowDefinitionBody[T] {
     override def transform(row: Seq[String]): T = f.apply(row)
   }
 
+  implicit def function1AsDataTableOptionalRowDefinitionBody[T](f: (Seq[Option[String]]) => T): DataTableOptionalRowDefinitionBody[T] = new DataTableOptionalRowDefinitionBody[T] {
+    override def transform(row: Seq[Option[String]]): T = f.apply(row)
+  }
 
   implicit def function1AsDataTableCellDefinitionBody[T](f: (String) => T): DataTableCellDefinitionBody[T] = new DataTableCellDefinitionBody[T] {
     override def transform(cell: String): T = f.apply(cell)
   }
 
+  implicit def function1AsDataTableOptionalCellDefinitionBody[T](f: (Option[String]) => T): DataTableOptionalCellDefinitionBody[T] = new DataTableOptionalCellDefinitionBody[T] {
+    override def transform(cell: Option[String]): T = f.apply(cell)
+  }
 
   implicit def function1AsDataTableDefinitionBody[T](f: (DataTable) => T): DataTableDefinitionBody[T] = new DataTableDefinitionBody[T] {
     override def transform(dataTable: DataTable): T = f.apply(dataTable)

--- a/scala/sources/src/main/scala/io/cucumber/scala/DataTableDefinitionBody.scala
+++ b/scala/sources/src/main/scala/io/cucumber/scala/DataTableDefinitionBody.scala
@@ -8,15 +8,33 @@ trait DataTableEntryDefinitionBody[T] {
 
 }
 
+trait DataTableOptionalEntryDefinitionBody[T] {
+
+  def transform(entry: Map[String, Option[String]]): T
+
+}
+
 trait DataTableRowDefinitionBody[T] {
 
   def transform(row: Seq[String]): T
 
 }
 
+trait DataTableOptionalRowDefinitionBody[T] {
+
+  def transform(row: Seq[Option[String]]): T
+
+}
+
 trait DataTableCellDefinitionBody[T] {
 
   def transform(cell: String): T
+
+}
+
+trait DataTableOptionalCellDefinitionBody[T] {
+
+  def transform(cell: Option[String]): T
 
 }
 

--- a/scala/sources/src/main/scala/io/cucumber/scala/ScalaDataTableOptionalCellDefinition.scala
+++ b/scala/sources/src/main/scala/io/cucumber/scala/ScalaDataTableOptionalCellDefinition.scala
@@ -1,0 +1,26 @@
+package io.cucumber.scala
+
+import io.cucumber.core.backend.ScenarioScoped
+import io.cucumber.datatable.{DataTableType, TableCellTransformer}
+
+trait ScalaDataTableOptionalCellDefinition[T] extends ScalaDataTableTypeDefinition {
+
+  val details: ScalaDataTableOptionalCellTypeDetails[T]
+
+  override val emptyPatterns: Seq[String] = details.emptyPatterns
+
+  override val location: StackTraceElement = new Exception().getStackTrace()(3)
+
+  private val transformer: TableCellTransformer[T] = (cell: String) => {
+    details.body.transform(Option(replaceEmptyPatternsWithEmptyString(cell)))
+  }
+
+  override val dataTableType = new DataTableType(details.tag.runtimeClass, transformer)
+
+}
+
+class ScalaScenarioScopedDataTableOptionalCellDefinition[T](override val details: ScalaDataTableOptionalCellTypeDetails[T]) extends ScalaDataTableOptionalCellDefinition[T] with ScenarioScoped {
+}
+
+class ScalaGlobalDataTableOptionalCellDefinition[T](override val details: ScalaDataTableOptionalCellTypeDetails[T]) extends ScalaDataTableOptionalCellDefinition[T] {
+}

--- a/scala/sources/src/main/scala/io/cucumber/scala/ScalaDataTableOptionalEntryDefinition.scala
+++ b/scala/sources/src/main/scala/io/cucumber/scala/ScalaDataTableOptionalEntryDefinition.scala
@@ -1,0 +1,33 @@
+package io.cucumber.scala
+
+import java.util.{Map => JavaMap}
+
+import io.cucumber.core.backend.ScenarioScoped
+import io.cucumber.datatable.{DataTableType, TableEntryTransformer}
+
+import scala.jdk.CollectionConverters._
+
+trait ScalaDataTableOptionalEntryDefinition[T] extends ScalaDataTableTypeDefinition {
+
+  val details: ScalaDataTableOptionalEntryTypeDetails[T]
+
+  override val emptyPatterns: Seq[String] = details.emptyPatterns
+
+  override val location: StackTraceElement = new Exception().getStackTrace()(3)
+
+  private val transformer: TableEntryTransformer[T] = (entry: JavaMap[String, String]) => {
+    replaceEmptyPatternsWithEmptyString(entry.asScala.toMap)
+      .map(_.map { case (k, v) => (k, Option(v)) })
+      .map(details.body.transform)
+      .get
+  }
+
+  override val dataTableType = new DataTableType(details.tag.runtimeClass, transformer)
+
+}
+
+class ScalaScenarioScopedDataTableOptionalEntryDefinition[T](override val details: ScalaDataTableOptionalEntryTypeDetails[T]) extends ScalaDataTableOptionalEntryDefinition[T] with ScenarioScoped {
+}
+
+class ScalaGlobalDataTableOptionalEntryDefinition[T](override val details: ScalaDataTableOptionalEntryTypeDetails[T]) extends ScalaDataTableOptionalEntryDefinition[T] {
+}

--- a/scala/sources/src/main/scala/io/cucumber/scala/ScalaDataTableOptionalRowDefinition.scala
+++ b/scala/sources/src/main/scala/io/cucumber/scala/ScalaDataTableOptionalRowDefinition.scala
@@ -1,0 +1,30 @@
+package io.cucumber.scala
+
+import java.util.{List => JavaList}
+
+import io.cucumber.core.backend.ScenarioScoped
+import io.cucumber.datatable.{DataTableType, TableRowTransformer}
+
+import scala.jdk.CollectionConverters._
+
+trait ScalaDataTableOptionalRowDefinition[T] extends ScalaDataTableTypeDefinition {
+
+  val details: ScalaDataTableOptionalRowTypeDetails[T]
+
+  override val emptyPatterns: Seq[String] = details.emptyPatterns
+
+  override val location: StackTraceElement = new Exception().getStackTrace()(3)
+
+  private val transformer: TableRowTransformer[T] = (row: JavaList[String]) => {
+    details.body.transform(row.asScala.map(replaceEmptyPatternsWithEmptyString).map(Option.apply).toSeq)
+  }
+
+  override val dataTableType = new DataTableType(details.tag.runtimeClass, transformer)
+
+}
+
+class ScalaScenarioScopedDataTableOptionalRowDefinition[T](override val details: ScalaDataTableOptionalRowTypeDetails[T]) extends ScalaDataTableOptionalRowDefinition[T] with ScenarioScoped {
+}
+
+class ScalaGlobalDataTableOptionalRowDefinition[T](override val details: ScalaDataTableOptionalRowTypeDetails[T]) extends ScalaDataTableOptionalRowDefinition[T] {
+}

--- a/scala/sources/src/main/scala/io/cucumber/scala/ScalaDataTableTypeDefinition.scala
+++ b/scala/sources/src/main/scala/io/cucumber/scala/ScalaDataTableTypeDefinition.scala
@@ -18,17 +18,35 @@ object ScalaDataTableTypeDefinition {
         } else {
           new ScalaGlobalDataTableEntryDefinition[T](entryDetails)
         }
+      case entryDetails@ScalaDataTableOptionalEntryTypeDetails(_, _, _) =>
+        if (scenarioScoped) {
+          new ScalaScenarioScopedDataTableOptionalEntryDefinition[T](entryDetails)
+        } else {
+          new ScalaGlobalDataTableOptionalEntryDefinition[T](entryDetails)
+        }
       case rowDetails@ScalaDataTableRowTypeDetails(_, _, _) =>
         if (scenarioScoped) {
           new ScalaScenarioScopedDataTableRowDefinition[T](rowDetails)
         } else {
           new ScalaGlobalDataTableRowDefinition[T](rowDetails)
         }
-      case rowDetails@ScalaDataTableCellTypeDetails(_, _, _) =>
+      case rowDetails@ScalaDataTableOptionalRowTypeDetails(_, _, _) =>
         if (scenarioScoped) {
-          new ScalaScenarioScopedDataTableCellDefinition[T](rowDetails)
+          new ScalaScenarioScopedDataTableOptionalRowDefinition[T](rowDetails)
         } else {
-          new ScalaGlobalDataTableCellDefinition[T](rowDetails)
+          new ScalaGlobalDataTableOptionalRowDefinition[T](rowDetails)
+        }
+      case cellDetails@ScalaDataTableCellTypeDetails(_, _, _) =>
+        if (scenarioScoped) {
+          new ScalaScenarioScopedDataTableCellDefinition[T](cellDetails)
+        } else {
+          new ScalaGlobalDataTableCellDefinition[T](cellDetails)
+        }
+      case cellDetails@ScalaDataTableOptionalCellTypeDetails(_, _, _) =>
+        if (scenarioScoped) {
+          new ScalaScenarioScopedDataTableOptionalCellDefinition[T](cellDetails)
+        } else {
+          new ScalaGlobalDataTableOptionalCellDefinition[T](cellDetails)
         }
       case rowDetails@ScalaDataTableTableTypeDetails(_, _, _) =>
         if (scenarioScoped) {

--- a/scala/sources/src/main/scala/io/cucumber/scala/ScalaDataTableTypeDetails.scala
+++ b/scala/sources/src/main/scala/io/cucumber/scala/ScalaDataTableTypeDetails.scala
@@ -6,9 +6,15 @@ sealed trait ScalaDataTableTypeDetails[T]
 
 case class ScalaDataTableEntryTypeDetails[T](emptyPatterns: Seq[String], body: DataTableEntryDefinitionBody[T], tag: ClassTag[T]) extends ScalaDataTableTypeDetails[T]
 
+case class ScalaDataTableOptionalEntryTypeDetails[T](emptyPatterns: Seq[String], body: DataTableOptionalEntryDefinitionBody[T], tag: ClassTag[T]) extends ScalaDataTableTypeDetails[T]
+
 case class ScalaDataTableRowTypeDetails[T](emptyPatterns: Seq[String], body: DataTableRowDefinitionBody[T], tag: ClassTag[T]) extends ScalaDataTableTypeDetails[T]
 
+case class ScalaDataTableOptionalRowTypeDetails[T](emptyPatterns: Seq[String], body: DataTableOptionalRowDefinitionBody[T], tag: ClassTag[T]) extends ScalaDataTableTypeDetails[T]
+
 case class ScalaDataTableCellTypeDetails[T](emptyPatterns: Seq[String], body: DataTableCellDefinitionBody[T], tag: ClassTag[T]) extends ScalaDataTableTypeDetails[T]
+
+case class ScalaDataTableOptionalCellTypeDetails[T](emptyPatterns: Seq[String], body: DataTableOptionalCellDefinitionBody[T], tag: ClassTag[T]) extends ScalaDataTableTypeDetails[T]
 
 case class ScalaDataTableTableTypeDetails[T](emptyPatterns: Seq[String], body: DataTableDefinitionBody[T], tag: ClassTag[T]) extends ScalaDataTableTypeDetails[T]
 

--- a/scala/sources/src/main/scala/io/cucumber/scala/ScalaDsl.scala
+++ b/scala/sources/src/main/scala/io/cucumber/scala/ScalaDsl.scala
@@ -208,12 +208,24 @@ private[scala] trait DataTableTypeDsl extends BaseScalaDsl {
       registry.registerDataTableType(ScalaDataTableEntryTypeDetails[T](replaceWithEmptyString, body, ev))
     }
 
+    def apply[T](body: DataTableOptionalEntryDefinitionBody[T])(implicit ev: ClassTag[T]): Unit = {
+      registry.registerDataTableType(ScalaDataTableOptionalEntryTypeDetails[T](replaceWithEmptyString, body, ev))
+    }
+
     def apply[T](body: DataTableRowDefinitionBody[T])(implicit ev: ClassTag[T]): Unit = {
       registry.registerDataTableType(ScalaDataTableRowTypeDetails[T](replaceWithEmptyString, body, ev))
     }
 
+    def apply[T](body: DataTableOptionalRowDefinitionBody[T])(implicit ev: ClassTag[T]): Unit = {
+      registry.registerDataTableType(ScalaDataTableOptionalRowTypeDetails[T](replaceWithEmptyString, body, ev))
+    }
+
     def apply[T](body: DataTableCellDefinitionBody[T])(implicit ev: ClassTag[T]): Unit = {
       registry.registerDataTableType(ScalaDataTableCellTypeDetails[T](replaceWithEmptyString, body, ev))
+    }
+
+    def apply[T](body: DataTableOptionalCellDefinitionBody[T])(implicit ev: ClassTag[T]): Unit = {
+      registry.registerDataTableType(ScalaDataTableOptionalCellTypeDetails[T](replaceWithEmptyString, body, ev))
     }
 
     def apply[T](body: DataTableDefinitionBody[T])(implicit ev: ClassTag[T]): Unit = {

--- a/scala/sources/src/test/resources/tests/datatables/DataTableType.feature
+++ b/scala/sources/src/test/resources/tests/datatables/DataTableType.feature
@@ -24,6 +24,14 @@ Feature: As Cucumber Scala, I want to parse properly Datatables and use types an
     When I concat their names
     Then I get "Alan,"
 
+  Scenario: Using a DataTableType for Entry with Option values - DataTable
+    Given the following authors as entries with null, as table
+      | name    | surname | famousBook      |
+      | [empty] | Alou    | The Lion King   |
+      |         | Bob     | Le Petit Prince |
+    When I concat their names
+    Then I get ",NoName"
+
   Scenario: Using a DataTableType for Row - Jlist
     Given the following authors as rows
       | Alan   | Alou | The Lion King   |
@@ -44,6 +52,13 @@ Feature: As Cucumber Scala, I want to parse properly Datatables and use types an
       | [empty] | Bob  | Le Petit Prince |
     When I concat their names
     Then I get "Alan,"
+
+  Scenario: Using a DataTableType for Row, with Option values - DataTable
+    Given the following authors as rows with null, as table
+      |         | Alou | The Lion King   |
+      | [empty] | Bob  | Le Petit Prince |
+    When I concat their names
+    Then I get "NoName,"
 
   Scenario: Using a DataTableType for Cell - Jlist[Jlist]
     Given the following authors as cells
@@ -75,12 +90,27 @@ Feature: As Cucumber Scala, I want to parse properly Datatables and use types an
     When I concat their names
     Then I get "Alan,"
 
-  Scenario: Using a DataTableType for Cell, with empty values - DataTable -> asLists
-    Given the following authors as cells with empty, as table as list
-      | Alan    | Alou    | The Lion King   |
+  Scenario: Using a DataTableType for Cell, with Option values - DataTable -> asMaps
+    Given the following authors as cells with null, as table as map
+      | name    | surname | famousBook      |
+      |         | Alou    | The Lion King   |
       | [empty] | Bob     | Le Petit Prince |
     When I concat their names
+    Then I get "NoName,"
+
+  Scenario: Using a DataTableType for Cell, with empty values - DataTable -> asLists
+    Given the following authors as cells with empty, as table as list
+      | Alan    | Alou | The Lion King   |
+      | [empty] | Bob  | Le Petit Prince |
+    When I concat their names
     Then I get "Alan,"
+
+  Scenario: Using a DataTableType for Cell, with Option values - DataTable -> asLists
+    Given the following authors as cells with null, as table as list
+      |         | Alou | The Lion King   |
+      | [empty] | Bob  | Le Petit Prince |
+    When I concat their names
+    Then I get "NoName,"
 
   Scenario: Using a DataTableType for DataTable - DataTable
     Given the following authors as table

--- a/scala/sources/src/test/scala/tests/datatables/DataTableTypeSteps.scala
+++ b/scala/sources/src/test/scala/tests/datatables/DataTableTypeSteps.scala
@@ -21,6 +21,10 @@ class DataTableTypeSteps extends ScalaDsl with EN {
     def toAuthor: Author = Author(name, surname, famousBook)
   }
 
+  case class AuthorWithNone(name: Option[String], surname: String, famousBook: String) {
+    def toAuthor: Author = Author(name.getOrElse("NoName"), surname, famousBook)
+  }
+
   case class AuthorRow(name: String, surname: String, famousBook: String) {
     def toAuthor: Author = Author(name, surname, famousBook)
   }
@@ -29,9 +33,15 @@ class DataTableTypeSteps extends ScalaDsl with EN {
     def toAuthor: Author = Author(name, surname, famousBook)
   }
 
+  case class AuthorRowWithNone(name: Option[String], surname: String, famousBook: String) {
+    def toAuthor: Author = Author(name.getOrElse("NoName"), surname, famousBook)
+  }
+
   case class AuthorCell(cell: String)
 
   case class AuthorCellWithEmpty(cell: String)
+
+  case class AuthorCellWithNone(cell: Option[String])
 
   var _authors: Seq[Author] = _
   var _names: String = _
@@ -44,6 +54,10 @@ class DataTableTypeSteps extends ScalaDsl with EN {
     AuthorWithEmpty(entry("name"), entry("surname"), entry("famousBook"))
   }
 
+  DataTableType("[empty]") { (entry: Map[String, Option[String]]) =>
+    AuthorWithNone(entry("name"), entry("surname").getOrElse("NoSurname"), entry("famousBook").getOrElse("NoFamousBook"))
+  }
+
   DataTableType { row: Seq[String] =>
     AuthorRow(row(0), row(1), row(2))
   }
@@ -52,12 +66,20 @@ class DataTableTypeSteps extends ScalaDsl with EN {
     AuthorRowWithEmpty(row(0), row(1), row(2))
   }
 
+  DataTableType("[empty]") { (row: Seq[Option[String]]) =>
+    AuthorRowWithNone(row(0), row(1).getOrElse("NoSurname"), row(2).getOrElse("NoBook"))
+  }
+
   DataTableType { cell: String =>
     AuthorCell(cell)
   }
 
   DataTableType("[empty]") { (cell: String) =>
     AuthorCellWithEmpty(cell)
+  }
+
+  DataTableType("[empty]") { (cell: Option[String]) =>
+    AuthorCellWithNone(cell)
   }
 
   DataTableType { table: DataTable =>
@@ -95,6 +117,12 @@ class DataTableTypeSteps extends ScalaDsl with EN {
       .map(_.toAuthor)
   }
 
+  Given("the following authors as entries with null, as table") { (authors: DataTable) =>
+    _authors = authors
+      .asScalaRawList[AuthorWithNone]
+      .map(_.toAuthor)
+  }
+
   Given("the following authors as rows") { (authors: JList[AuthorRow]) =>
     _authors = authors
       .asScala
@@ -112,6 +140,12 @@ class DataTableTypeSteps extends ScalaDsl with EN {
   Given("the following authors as rows with empty, as table") { (authors: DataTable) =>
     _authors = authors
       .asScalaRawList[AuthorRowWithEmpty]
+      .map(_.toAuthor)
+  }
+
+  Given("the following authors as rows with null, as table") { (authors: DataTable) =>
+    _authors = authors
+      .asScalaRawList[AuthorRowWithNone]
       .map(_.toAuthor)
   }
 
@@ -145,10 +179,22 @@ class DataTableTypeSteps extends ScalaDsl with EN {
       .map(line => Author(line("name").cell, line("surname").cell, line("famousBook").cell))
   }
 
+  Given("the following authors as cells with null, as table as map") { (authors: DataTable) =>
+    _authors = authors
+      .asScalaRawMaps[String, AuthorCellWithNone]
+      .map(line => Author(line("name").cell.getOrElse("NoName"), line("surname").cell.getOrElse("NoSurname"), line("famousBook").cell.getOrElse("NoBook")))
+  }
+
   Given("the following authors as cells with empty, as table as list") { (authors: DataTable) =>
     _authors = authors
       .asScalaRawLists[AuthorCellWithEmpty]
       .map(line => Author(line(0).cell, line(1).cell, line(2).cell))
+  }
+
+  Given("the following authors as cells with null, as table as list") { (authors: DataTable) =>
+    _authors = authors
+      .asScalaRawLists[AuthorCellWithNone]
+      .map(line => Author(line(0).cell.getOrElse("NoName"), line(1).cell.getOrElse("NoSurname"), line(2).cell.getOrElse("NoBook")))
   }
 
   Given("the following authors as table") { (authors: DataTable) =>
@@ -164,7 +210,7 @@ class DataTableTypeSteps extends ScalaDsl with EN {
   }
 
   Then("""I get {string}""") { expected: String =>
-    assert(_names == expected)
+    assert(_names == expected, s"${_names} was not equal to $expected")
   }
 
 }

--- a/scala/sources/src/test/scala/tests/datatables/DataTableTypeSteps.scala
+++ b/scala/sources/src/test/scala/tests/datatables/DataTableTypeSteps.scala
@@ -3,6 +3,7 @@ package tests.datatables
 import io.cucumber.scala.{EN, ScalaDsl}
 import java.util.{List => JList, Map => JMap}
 
+import io.cucumber.scala.Implicits._
 import io.cucumber.datatable.DataTable
 
 import scala.jdk.CollectionConverters._
@@ -90,9 +91,7 @@ class DataTableTypeSteps extends ScalaDsl with EN {
 
   Given("the following authors as entries with empty, as table") { (authors: DataTable) =>
     _authors = authors
-      .asList[AuthorWithEmpty](classOf[AuthorWithEmpty])
-      .asScala
-      .toSeq
+      .asScalaRawList[AuthorWithEmpty]
       .map(_.toAuthor)
   }
 
@@ -112,9 +111,7 @@ class DataTableTypeSteps extends ScalaDsl with EN {
 
   Given("the following authors as rows with empty, as table") { (authors: DataTable) =>
     _authors = authors
-      .asList[AuthorRowWithEmpty](classOf[AuthorRowWithEmpty])
-      .asScala
-      .toSeq
+      .asScalaRawList[AuthorRowWithEmpty]
       .map(_.toAuthor)
   }
 
@@ -144,19 +141,13 @@ class DataTableTypeSteps extends ScalaDsl with EN {
 
   Given("the following authors as cells with empty, as table as map") { (authors: DataTable) =>
     _authors = authors
-      .asMaps[String, AuthorCellWithEmpty](classOf[String], classOf[AuthorCellWithEmpty])
-      .asScala
-      .toSeq
-      .map(_.asScala)
+      .asScalaRawMaps[String, AuthorCellWithEmpty]
       .map(line => Author(line("name").cell, line("surname").cell, line("famousBook").cell))
   }
 
   Given("the following authors as cells with empty, as table as list") { (authors: DataTable) =>
     _authors = authors
-      .asLists[AuthorCellWithEmpty](classOf[AuthorCellWithEmpty])
-      .asScala
-      .toSeq
-      .map(_.asScala)
+      .asScalaRawLists[AuthorCellWithEmpty]
       .map(line => Author(line(0).cell, line(1).cell, line(2).cell))
   }
 


### PR DESCRIPTION
Aims to resolve #84 

Add the 3 following new possible definitions:
  - `DataTableType { (entry: Map[String, Option[String]]) => ... }`
  - `DataTableType { (row: Seq[Option[String]]) => ... }`
  - `DataTableType { (cell: Option[String]) => ... }`