### PR TITLE
Version policy

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,7 +29,7 @@ jobs:
           ~/.cache/coursier
         key: ${{ runner.os }}-sbt-cache-v2-${{ hashFiles('**/*.sbt') }}-${{ hashFiles('project/build.properties') }}
 
-    - name: Set up JDK 1.8
+    - name: Set up JDK
       uses: actions/setup-java@v1
       with:
         java-version: ${{ matrix.java }}
@@ -39,3 +39,33 @@ jobs:
 
     - name: Run tests
       run: sbt +compile +test
+
+  versionpolicycheck:
+    name: Version policy check
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ ubuntu-latest ]
+        java:
+          - 11
+    runs-on: ${{ matrix.os }}
+    steps:
+
+      - uses: actions/checkout@v2
+
+      - name: Cache sbt
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.sbt
+            ~/.ivy2/cache
+            ~/.cache/coursier
+          key: ${{ runner.os }}-sbt-cache-v2-${{ hashFiles('**/*.sbt') }}-${{ hashFiles('project/build.properties') }}
+
+      - name: Set up JDK
+        uses: actions/setup-java@v1
+        with:
+          java-version: ${{ matrix.java }}
+
+      - name: Version check
+        run: sbt "project cucumberScala" versionPolicyCheck

--- a/build.sbt
+++ b/build.sbt
@@ -118,6 +118,10 @@ lazy val examples = (projectMatrix in file("examples"))
   .dependsOn(cucumberScala % Test)
   .jvmPlatform(scalaVersions = Seq(scala213, scala212))
 
+// Version policy check
+
+ThisBuild / versionPolicyIntention := Compatibility.BinaryAndSourceCompatible
+
 // Release & Publish
 
 Global / publishMavenStyle := true

--- a/build.sbt
+++ b/build.sbt
@@ -120,6 +120,7 @@ lazy val examples = (projectMatrix in file("examples"))
 
 // Version policy check
 
+ThisBuild / versionScheme := Some("early-semver")
 ThisBuild / versionPolicyIntention := Compatibility.BinaryAndSourceCompatible
 
 // Release & Publish

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.4.5
+sbt.version=1.4.7

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -4,6 +4,9 @@ addSbtPlugin("com.eed3si9n" % "sbt-projectmatrix" % "0.7.0")
 // Scalafmt (formatter)
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.4.2")
 
+// Version policy check
+addSbtPlugin("ch.epfl.scala" % "sbt-version-policy" % "1.0.0-RC5")
+
 // Release
 addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.13")
 


### PR DESCRIPTION
This MR aims to cover two things:
- define the `versionScheme` that the library follows as recommended for upcoming sbt 1.5.x
- provide feedback on MR about binary/source compatibility by using _sbt-version-polivy_ plugin

More info at https://www.scala-lang.org/blog/2021/02/16/preventing-version-conflicts-with-versionscheme.html