### PR TITLE
chore: 🤖 Remove the custom gpg script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,6 +35,8 @@ update-changelog:
 
 .configure-cukebot-in-docker:
 	[ -f '/home/cukebot/configure' ] && /home/cukebot/configure
+	# Cucumber team provides the passphrase in this variable
+	export PGP_PASSPHRASE="$GPG_SIGNING_KEY_PASSPHRASE"
 .PHONY: .configure-cukebot-in-docker
 
 .release-in-docker: .configure-cukebot-in-docker default update-changelog update-installdoc .commit-and-push-changelog-and-docs

--- a/build.sbt
+++ b/build.sbt
@@ -128,9 +128,6 @@ ThisBuild / versionPolicyIntention := Compatibility.BinaryAndSourceCompatible
 Global / publishMavenStyle := true
 Global / publishTo := sonatypePublishToBundle.value
 
-// https://github.com/sbt/sbt-pgp/issues/173
-Global / PgpKeys.gpgCommand := (baseDirectory.value / "gpg.sh").getAbsolutePath
-
 // https://github.com/xerial/sbt-sonatype#using-with-sbt-release-plugin
 releaseCrossBuild := true
 releaseProcess := Seq[ReleaseStep](

--- a/gpg.sh
+++ b/gpg.sh
@@ -1,3 +1,0 @@
-#! /bin/sh
-
-gpg --passphrase "${GPG_SIGNING_KEY_PASSPHRASE}" --pinentry-mode loopback $@

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -12,4 +12,4 @@ addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.13")
 
 // Publishing
 addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.9.5")
-addSbtPlugin("com.jsuereth" % "sbt-pgp" % "2.0.1")
+addSbtPlugin("com.github.sbt" % "sbt-pgp" % "2.1.2")


### PR DESCRIPTION
Latest sbt-pgp release fixes the original issue and read the passphrase in `PGP_PASSPHRASE` environment variable now.