### PR TITLE
Allow usage of class with args and dependency injection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ See also the [CHANGELOG](https://github.com/cucumber/cucumber-jvm/blob/master/CH
 
 ### Fixed
 
+- [Scala] Integration with DI modules like `cucumber-picocontainer` is now working
+
 ## [8.3.3] (2022-05-04)
 
 ### Changed

--- a/build.sbt
+++ b/build.sbt
@@ -66,6 +66,7 @@ lazy val root = (project in file("."))
     cucumberScala.projectRefs ++
       integrationTestsCommon.projectRefs ++
       integrationTestsJackson.projectRefs ++
+      integrationTestsPicoContainer.projectRefs ++
       examples.projectRefs: _*
   )
 
@@ -145,6 +146,21 @@ lazy val integrationTestsJackson =
         "junit" % "junit" % junitVersion % Test,
         "io.cucumber" % "cucumber-junit" % cucumberVersion % Test,
         "com.fasterxml.jackson.module" %% "jackson-module-scala" % jacksonVersion % Test
+      ),
+      publishArtifact := false
+    )
+    .dependsOn(cucumberScala % Test)
+    .jvmPlatform(scalaVersions = Seq(scala3, scala213, scala212))
+
+lazy val integrationTestsPicoContainer =
+  (projectMatrix in file("integration-tests/picocontainer"))
+    .settings(commonSettings)
+    .settings(
+      name := "integration-tests-picocontainer",
+      libraryDependencies ++= Seq(
+        "junit" % "junit" % junitVersion % Test,
+        "io.cucumber" % "cucumber-junit" % cucumberVersion % Test,
+        "io.cucumber" % "cucumber-picocontainer" % cucumberVersion % Test
       ),
       publishArtifact := false
     )

--- a/cucumber-scala/src/main/scala/io/cucumber/scala/UnknownClassType.scala
+++ b/cucumber-scala/src/main/scala/io/cucumber/scala/UnknownClassType.scala
@@ -1,0 +1,9 @@
+package io.cucumber.scala
+
+import io.cucumber.core.backend.CucumberBackendException
+
+class UnknownClassType(clazz: Class[_], cause: Throwable)
+    extends CucumberBackendException(
+      s"Cucumber was not able to handle class ${clazz.getName}. Please report this issue to cucumber-scala project.",
+      cause
+    )

--- a/cucumber-scala/src/test/scala/io/cucumber/scala/steps/dependencyinjection/Injected.scala
+++ b/cucumber-scala/src/test/scala/io/cucumber/scala/steps/dependencyinjection/Injected.scala
@@ -1,0 +1,13 @@
+package io.cucumber.scala.steps.dependencyinjection
+
+import io.cucumber.scala.{EN, ScalaDsl}
+
+class Injected extends ScalaDsl with EN {
+
+  var x: String = _
+
+  Given("""injected steps""") { () =>
+    // Nothing
+  }
+
+}

--- a/cucumber-scala/src/test/scala/io/cucumber/scala/steps/dependencyinjection/Injector.scala
+++ b/cucumber-scala/src/test/scala/io/cucumber/scala/steps/dependencyinjection/Injector.scala
@@ -1,0 +1,11 @@
+package io.cucumber.scala.steps.dependencyinjection
+
+import io.cucumber.scala.{EN, ScalaDsl}
+
+class Injector(injected: Injected) extends ScalaDsl with EN {
+
+  Then("""Injector""") { () =>
+    println(injected.x)
+  }
+
+}

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -50,6 +50,37 @@ You can also define glue code in **objects**.
 Be aware that by definition objects are singleton and if your glue code is stateful you will probably have "state conflicts"
 between your scenarios if you use shared variables from objects.
 
+### Using dependency-injection
+
+Starting with cucumber-scala 8.4, it is possible to use DI modules in order to share state between steps.
+
+You can for instance have the following definition:
+```scala
+import io.cucumber.scala.{EN, ScalaDsl}
+
+class A extends ScalaDsl with EN {
+
+  var input: String = _
+
+  Given("""a step defined in class A with arg {string}""") { (arg: String) =>
+    input = arg
+  }
+
+}
+
+class B(a: A) extends ScalaDsl with EN {
+
+  When("""a step defined in class B uses A""") { () =>
+    // Do something with a.input
+    println(a.input)
+  }
+
+}
+```
+
+To make it work, you only need a Cucumber DI module to be added as a dependency of your project
+(like `cucumber-picocontainer`, or `cucumber-guice`, or any other provided by Cucumber).
+
 ## Running Cucumber tests
 
 See also the Running Cucumber for Java [documentation](https://docs.cucumber.io/docs/cucumber/api/#running-cucumber).

--- a/integration-tests/picocontainer/src/test/resources/cucumber.properties
+++ b/integration-tests/picocontainer/src/test/resources/cucumber.properties
@@ -1,0 +1,1 @@
+cucumber.publish.quiet=true

--- a/integration-tests/picocontainer/src/test/resources/di/di.feature
+++ b/integration-tests/picocontainer/src/test/resources/di/di.feature
@@ -1,0 +1,7 @@
+Feature: As Cucumber Scala, I want to be able to have some step classes depend on another one
+
+  Scenario: Nominal case
+    Given a step defined in class DI-A with arg "A"
+    And a step defined in class DI-B with arg "B"
+    When a step defined in class DI-C uses them both
+    Then both values are combined into "AB"

--- a/integration-tests/picocontainer/src/test/scala/di/DI_A.scala
+++ b/integration-tests/picocontainer/src/test/scala/di/DI_A.scala
@@ -1,0 +1,13 @@
+package di
+
+import io.cucumber.scala.{EN, ScalaDsl}
+
+class DI_A extends ScalaDsl with EN {
+
+  var input: String = _
+
+  Given("""a step defined in class DI-A with arg {string}""") { (arg: String) =>
+    input = arg
+  }
+
+}

--- a/integration-tests/picocontainer/src/test/scala/di/DI_B.scala
+++ b/integration-tests/picocontainer/src/test/scala/di/DI_B.scala
@@ -1,0 +1,13 @@
+package di
+
+import io.cucumber.scala.{EN, ScalaDsl}
+
+class DI_B extends ScalaDsl with EN {
+
+  var input: String = _
+
+  Given("""a step defined in class DI-B with arg {string}""") { (arg: String) =>
+    input = arg
+  }
+
+}

--- a/integration-tests/picocontainer/src/test/scala/di/DI_C.scala
+++ b/integration-tests/picocontainer/src/test/scala/di/DI_C.scala
@@ -1,0 +1,17 @@
+package di
+
+import io.cucumber.scala.{EN, ScalaDsl}
+
+class DI_C(a: DI_A, b: DI_B) extends ScalaDsl with EN {
+
+  private var combination: String = _
+
+  When("""a step defined in class DI-C uses them both""") { () =>
+    combination = a.input + b.input
+  }
+
+  Then("""both values are combined into {string}""") { (expected: String) =>
+    assert(combination == expected)
+  }
+
+}

--- a/integration-tests/picocontainer/src/test/scala/di/RunDependencyInjectionTest.scala
+++ b/integration-tests/picocontainer/src/test/scala/di/RunDependencyInjectionTest.scala
@@ -1,0 +1,8 @@
+package di
+
+import io.cucumber.junit.{Cucumber, CucumberOptions}
+import org.junit.runner.RunWith
+
+@RunWith(classOf[Cucumber])
+@CucumberOptions()
+class RunDependencyInjectionTest


### PR DESCRIPTION
### 🤔 What's changed?

This PR fixes the way `class` vs `object` are identified by Cucumber Scala: until now, any class not having a no-arg constructor was assumed to be an `object` which is false.

With this PR, classes with no public constructor are considered to be `object` but other ones (including classes with 1-arg or 2-args.. constructors) are considered as regular classes.

This has the side-effect of **fixing integration with picocontainer and other DI modules** available with Cucumber.

_Note: the identification of wheter a type is a `class` or an `object` is still perfectible but should be good in 99% of the cases. Additional error messages have been added so that users which would be in the remaining 1% are able to have a clearer error and contact us._

### ⚡️ What's your motivation? 

Fixes #4  and #175 .

### 🏷️ What kind of change is this?

- :bug: Bug fix (non-breaking change which fixes a defect)
- :zap: New feature (non-breaking change which adds new behaviour)

### ♻️ Anything particular you want feedback on?

N/A

### 📋 Checklist:

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://cucumber.io/conduct/)
- [x] I've changed the behaviour of the code
  - [x] I have added/updated tests to cover my changes.
- [x] My change requires a change to the documentation.
  - [x] I have updated the documentation accordingly.
- [x] Users should know about my change
  - [x] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../CHANGELOG.md), linking to this pull request.
