### PR TITLE
Upgrade Scala3 version to 3.2.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ See also the [CHANGELOG](https://github.com/cucumber/cucumber-jvm/blob/master/CH
 ### Changed
 
 - [Core] Updated `cucumber-core` dependency to [7.10.0](https://github.com/cucumber/cucumber-jvm/blob/main/CHANGELOG.md)
+- [Scala] Upgrade Scala 3 version to 3.2.1
+
 - [Scala] Updated `scala-collection-compat` dependency to 2.9.0
 - [Build] Updated `scalafmt` dependency to 2.5.0
 - [Build] Updated `sbt-sonatype` dependency to 3.9.15

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ See also the [CHANGELOG](https://github.com/cucumber/cucumber-jvm/blob/master/CH
 - [Scala] Upgrade Scala 3 version to 3.2.1
 
 - [Scala] Updated `scala-collection-compat` dependency to 2.9.0
+- [Build] Updated `jackson` dependency to 2.14.1 
 - [Build] Updated `scalafmt` dependency to 2.5.0
 - [Build] Updated `sbt-sonatype` dependency to 3.9.15
 - [Build] Updated `sbt-version-policy` dependency to 2.1.0

--- a/README.md
+++ b/README.md
@@ -19,13 +19,14 @@ of Cucumber Core projects.
 
 The table below shows the compatible versions:
 
-| Cucumber Scala version | Cucumber Core version | Scala versions        |
-|------------------------|-----------------------|-----------------------|
-| 8.x                    | 7.x                   | 2.12, 2.13, 3.0       |
-| 7.x                    | 6.x                   | 2.11, 2.12, 2.13, 3.0 |
-| 6.x                    | 6.x                   | 2.11, 2.12, 2.13      |
-| 5.x                    | 5.x                   | 2.11, 2.12, 2.13      |
-| 4.x                    | 4.x                   | 2.11, 2.12, 2.13      |
+| Cucumber Scala version | Cucumber Core version | Scala versions         |
+|------------------------|-----------------------|------------------------|
+| 8.13+                  | 7.x                   | 2.12, 2.13, 3.2+       |
+| 8.0-8.12               | 7.x                   | 2.12, 2.13, 3.0+       |
+| 7.x                    | 6.x                   | 2.11, 2.12, 2.13, 3.0+ |
+| 6.x                    | 6.x                   | 2.11, 2.12, 2.13       |
+| 5.x                    | 5.x                   | 2.11, 2.12, 2.13       |
+| 4.x                    | 4.x                   | 2.11, 2.12, 2.13       |
 
 ## Getting started
 

--- a/build.sbt
+++ b/build.sbt
@@ -32,7 +32,7 @@ ThisBuild / homepage := Some(
 
 val scala212 = "2.12.16"
 val scala213 = "2.13.10"
-val scala3 = "3.1.3"
+val scala3 = "3.2.1"
 
 scalaVersion := scala213
 

--- a/build.sbt
+++ b/build.sbt
@@ -39,7 +39,7 @@ scalaVersion := scala213
 // Library versions
 
 val cucumberVersion = "7.10.0"
-val jacksonVersion = "2.13.4"
+val jacksonVersion = "2.14.1"
 val mockitoScalaVersion = "1.17.12"
 val junitVersion = "4.13.2"
 


### PR DESCRIPTION
Following recommendations at https://www.scala-lang.org/blog/2022/08/17/long-term-compatibility-plans.html

This also allows to upgrade Jackson dependency (in provided scope though) to 2.14.x as it's only built for Scala 3.2+.