### PR TITLE
Automatically merge minor and patch upgrades

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,10 +1,14 @@
 name: Cucumber Scala CI
 
 on:
+  workflow_call:
   pull_request:
     branches:
-    - main
-  workflow_call: {}
+      - main
+  push:
+    branches:
+      - main
+      - renovate/**
 
 jobs:
   build:


### PR DESCRIPTION
### ⚡️ What's your motivation? 

Currently the test action is configured to only run on pull requests. This means Renovate had to make https://github.com/cucumber/cucumber-jvm-scala/pull/360 to see if the change it wanted to make would pass. 

Renovate works best when it can quietly upgrade minor and patch changes when there is a passing build. This requires running the CI jobs for pushes to `renovate/**` branches.  

By enabling builds on pushes to  `renovate/**` Renovate can quietly do it's work. Additionally building any pushes to `main` will ensure that if multiple MR's cross each other when being merged, the build status for each will be known making it easier to isolate problems.

### 🏷️ What kind of change is this?

- :bank: Refactoring/debt/DX (improvement to code design, tooling, documentation etc. without changing behaviour)
