### PR TITLE
Bump Scala 2.12.16 to 2.12.18 for JDK21

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ See also the [CHANGELOG](https://github.com/cucumber/cucumber-jvm/blob/master/CH
 
 ### Changed
 
+- [Build] Upgraded Scala 2.12.16 to 2.12.18 for JDK 21 purposes.
+
 ### Deprecated
 
 ### Removed

--- a/build.sbt
+++ b/build.sbt
@@ -30,7 +30,7 @@ ThisBuild / homepage := Some(
 
 // Scala versions
 
-val scala212 = "2.12.16"
+val scala212 = "2.12.18"
 val scala213 = "2.13.12"
 val scala3 = "3.3.1"
 


### PR DESCRIPTION
### 🤔 What's changed?

Since we want to support JDK 21 we need to bump Scala up to 2.12.18

### ⚡️ What's your motivation? 

PR https://github.com/cucumber/cucumber-jvm-scala/pull/365

### 🏷️ What kind of change is this?

- :boom: Scala bump 2.12.16 to 2.12.18

### ♻️ Anything particular you want feedback on?

### 📋 Checklist:

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://cucumber.io/conduct/)
