### PR TITLE
Configure Sonatype Nexus Username

### DIFF
--- a/.github/workflows/release-sbt.yml
+++ b/.github/workflows/release-sbt.yml
@@ -34,9 +34,8 @@ jobs:
         with:
           gpg-private-key: ${{ secrets.GPG_PRIVATE_KEY }}
           gpg-passphrase: ${{ secrets.GPG_PASSPHRASE }}
-          nexus-username: cukebot
+          nexus-username: ${{ secrets.SONATYPE_USERNAME }}
           nexus-password: ${{ secrets.SONATYPE_PASSWORD }}
-          working-directory: .
 
   create-github-release:
     name: Create GitHub Release and Git tag


### PR DESCRIPTION
With Sonatype requiring the usage of a token instead of username/password. The username can no longer be hardcoded and must also be read from secrets.

Fixes: #376
