### PR TITLE
🏗️ build: explicit the target Java 8

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -60,6 +60,8 @@ lazy val commonSettings = Seq(
       case _             => Seq()
     }
   },
+  // Explicitly set target to Java 8
+  scalacOptions += "-release:8",
   // Load BOMs
   junitBom,
   // Add all dependencies of the BOM in dependencyOverrides


### PR DESCRIPTION
That's currently the default target (in Scala or is it SBT?) but let's be explicit as this may change in a near future.