### PR TITLE
Add OpenSSF Scorecard badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,21 @@
-# Cucumber Scala
+<h1 align="center">
+  <img src="https://raw.githubusercontent.com/cucumber/cucumber-js/46a5a78107be27e99c6e044c69b6e8f885ce456c/docs/images/logo.svg" alt="Cucumber logo" width="75">
+  <br>
+  Cucumber Scala
+</h1>
+<div align="center">
+
+**Cucumber Scala is the Scala implementation of [Cucumber](https://cucumber.io/).**
+
+</div>
+
+<div align="center">
 
 [![Maven Central](https://img.shields.io/maven-central/v/io.cucumber/cucumber-scala_2.13.svg?label=Maven%20Central)](https://search.maven.org/search?q=g:%22io.cucumber%22%20AND%20a:%22cucumber-scala_2.13%22)
-![Build Status](https://github.com/cucumber/cucumber-jvm-scala/workflows/Cucumber%20Scala%20CI/badge.svg)
+[![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/cucumber/cucumber-jvm-scala/badge)](https://scorecard.dev/viewer/?uri=github.com/cucumber/cucumber-jvm-scala)
 
-Cucumber Scala is the Scala implementation of [Cucumber](https://cucumber.io/).
+![Build Status](https://github.com/cucumber/cucumber-jvm-scala/workflows/Cucumber%20Scala%20CI/badge.svg)
+</div>
 
 ## Help & Support
 


### PR DESCRIPTION
### 🤔 What's changed?

* Added OpenSSF Scorecard badge
* Spruced up the header a bit
* Because the GitHub actions badge has a different style I've put it on a separate line.

### ⚡️ What's your motivation? 

We improved the Cucumber orgs security stance a bit. The OpenSSF Scorecard provides a way to display that stance as a number. The current score of 6.5 is a bit low compared to other Cucumber repositories above 7.0. The difference can be mostly attributed to a lack of a SAST, CodeQL doesn't support Scala. So I don't think that is an important difference.


Contribute to: https://github.com/cucumber/common/issues/2312


### 🏷️ What kind of change is this?
- :book: Documentation (improvements without changing code)

### ♻️ Anything particular you want feedback on?

@gaeljw up to you if you want to display it. 

Overall we also get low scores for code-review and not requiring PR's for all changes. This primarily caused by using Renovate to automatically update our dependencies. Personally, I don't think the requirements the scorecard puts down to get good marks here are worth it though for a mostly unpaid opensource project. 

### 📋 Checklist:


- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://github.com/cucumber/.github/tree/main?tab=coc-ov-file)
