### PR TITLE
Make releases from tags instead of branches

### DIFF
--- a/.github/workflows/release-github.yaml
+++ b/.github/workflows/release-github.yaml
@@ -4,11 +4,12 @@ permissions: {}
 
 on:
   push:
-    branches: [release/*]
+    tags:
+      - 'v[0-9]+.[0-9]+.[0-9]+'
 
 jobs:
   create-github-release:
-    name: Create GitHub Release and Git tag
+    name: Create GitHub Release
     runs-on: ubuntu-latest
     environment: Release
     permissions:

--- a/.github/workflows/release-sbt.yaml
+++ b/.github/workflows/release-sbt.yaml
@@ -4,8 +4,8 @@ permissions: {}
 
 on:
   push:
-    branches:
-      - release/*
+    tags:
+      - 'v[0-9]+.[0-9]+.[0-9]+'
 
 jobs:
   publish-sbt:
@@ -17,10 +17,6 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
-
-      - run: |
-          git config user.name github-actions
-          git config user.email github-actions@github.com
 
       - uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5.7.0
         with:

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -11,20 +11,21 @@ See [Cucumber release process](https://github.com/cucumber/.github/blob/main/REL
    ```bash
    export next_release=<version> # <- insert version number here
    ```
-1. Update the `version.sbt` file with version to release:
+2. Update the `version.sbt` file with version to release:
     ```bash
     echo "ThisBuild / version := \"$next_release\"" > version.sbt
     ```
-1. Update the CHANGELOG and documentation, commit and push:
+3. Update the CHANGELOG and documentation, commit and push:
     ```bash
     make prepare-release
     ```
 
 ## Release
 
-1. Push to a new `release/*` branch to trigger the `release-*` workflows
+1. Push to a new tag to trigger the `release-*` workflows
    ```bash
-   git push origin main:release/v$next_release
+   git tag --message "v$next_release" "v$next_release"
+   git push origin main "v$next_release"
    ```
-1. Wait until the `release-*` workflows in GitHub Actions have passed
-1. In `version.sbt`, bump the **patch** version and append `-SNAPSHOT` (e.g. `1.2.4-SNAPSHOT`) and commit/push
+2. Wait until the `release-*` workflows in GitHub Actions have passed
+3. In `version.sbt`, bump the **patch** version and append `-SNAPSHOT` (e.g. `1.2.4-SNAPSHOT`) and commit/push


### PR DESCRIPTION
### ⚡️ What's your motivation? 

When setting up the original release process, GitHub did not have protected tags. Instead, we used protected branches. This is no longer necessary.


### 🏷️ What kind of change is this?

- :bank: Refactoring/debt/DX (improvement to code design, tooling, etc. without changing behaviour)


### 📋 Checklist:
- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://github.com/cucumber/.github/tree/main?tab=coc-ov-file)

